### PR TITLE
Ensure basic bundler rake tasks are loaded

### DIFF
--- a/contrib/ruby/Rakefile
+++ b/contrib/ruby/Rakefile
@@ -1,4 +1,4 @@
-require "bundler/gem_helper"
+require "bundler/gem_tasks"
 require "rake/extensiontask"
 
 Rake::ExtensionTask.new do |ext|


### PR DESCRIPTION
The ruby contrib readme [states](https://github.com/github/trilogy/tree/main/contrib/ruby#building) we should be able to build the gem using `bundle exec rake build`, but as-is bundler errors with `Don't know how to build task 'build'` and `rake -T` shows only the locally defined tasks 

```sh
$ bundle exec rake -T
rake clean         # Remove any temporary products
rake clobber       # Remove any generated files
rake compile       # Compile all the extensions
rake compile:cext  # Compile cext
```

Bundler 2.x gems typically include `bundler/gem_tasks` instead of `bundler/gem_helper`. Updating the Rakefile likewise gives us the bundler tasks for building the project

```sh
$ bundle exec rake -T
rake build            # Build trilogy-2.0.0.gem into the pkg directory
rake build:checksum   # Generate SHA512 checksum if trilogy-2.0.0.gem into the checksums directory
rake clean            # Remove any temporary products
rake clobber          # Remove any generated files
rake compile          # Compile all the extensions
rake compile:cext     # Compile cext
rake install          # Build and install trilogy-2.0.0.gem into system gems
rake install:local    # Build and install trilogy-2.0.0.gem into system gems without network access
rake release[remote]  # Create tag v2.0.0 and build and push trilogy-2.0.0.gem to rubygems.org
```

cc/ @eileencodes 