### PR TITLE
Add pull_request to CI action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
Without this change the CI actions won't run on pull requests from
forks. Now that we're open source, this is a requirement to support.