### PR TITLE
Fix actions for macos too

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,5 +1,5 @@
 name: macOS
-on: [push]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
Add pull_request to the list of actions so that PRs opened via forks
will run CI.

Forgot this when I opened #5.