### PR TITLE
Silence clang 13 warnings

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/extconf.rb
+++ b/contrib/ruby/ext/trilogy-ruby/extconf.rb
@@ -8,6 +8,10 @@ File.binwrite("trilogy.c",
 $objs = %w[trilogy.o cast.o cext.o]
 $CFLAGS << " -I #{__dir__}/inc -std=gnu99"
 
+# clang 13 warnings, may need to be addressed
+$CFLAGS << " -Wno-string-plus-int"
+$CFLAGS << " -Wno-shorten-64-to-32"
+
 dir_config("openssl")
 
 have_library("crypto", "CRYPTO_malloc")


### PR DESCRIPTION
They should probably be addressed, but in the meantime they make the compilation output hard to read.