### PR TITLE
ruby: use rb_interned_str when available

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -631,8 +631,12 @@ static VALUE execute_read_query(VALUE vargs)
             }
         }
 
+#ifdef HAVE_RB_INTERNED_STR
+        VALUE column_name = rb_interned_str(column.name, column.name_len);
+#else
         VALUE column_name = rb_str_new(column.name, column.name_len);
         OBJ_FREEZE(column_name);
+#endif
 
         rb_ary_push(column_names, column_name);
 

--- a/contrib/ruby/ext/trilogy-ruby/extconf.rb
+++ b/contrib/ruby/ext/trilogy-ruby/extconf.rb
@@ -12,5 +12,6 @@ dir_config("openssl")
 
 have_library("crypto", "CRYPTO_malloc")
 have_library("ssl", "SSL_new")
+have_func("rb_interned_str", "ruby.h")
 
 create_makefile "trilogy/cext"


### PR DESCRIPTION
This API was introduced with Ruby 3.0
Ref: https://bugs.ruby-lang.org/issues/16029

It allows to re-used an existing interned string when possible. Since column names are very often present in the codebase, the hitrate is generally good.

One issue here however is that column names are created in ASCII because the Ruby client doesn't know what the connection encoding is.

So it won't be able to re-use literal strings from the codebase, however it will re-use the strings backing symbols (they are ASCII).

But even on misses, since `Hash#[]=` will always try to dedup the string by always getting an interned string, we save that extra lookup later when using `Result#each_hash`.

Similar change in MySQL2: https://github.com/brianmario/mysql2/pull/1181