### PR TITLE
Fix clang 13 `string-plus-int` warnings

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -927,7 +927,7 @@ void Init_cext()
     rb_trilogy_cast_init();
 
 // server_status flags
-#define XX(name, code) rb_const_set(Trilogy, rb_intern(#name + strlen("TRILOGY_")), LONG2NUM(name));
+#define XX(name, code) rb_const_set(Trilogy, rb_intern((char *)#name + strlen("TRILOGY_")), LONG2NUM(name));
     TRILOGY_SERVER_STATUS(XX)
 #undef XX
 }


### PR DESCRIPTION
Fix the second half of #8 

```
../../../../ext/trilogy-ruby/cext.c:931:27: warning: adding 'unsigned long' to a string does not append to the string [-Wstring-plus-int]
    TRILOGY_SERVER_STATUS(XX)
    ~~~~~~~~~~~~~~~~~~~~~~^~~
/Users/byroot/src/github.com/github/trilogy/contrib/ruby/ext/trilogy-ruby/inc/trilogy/protocol.h:273:5: note: expanded from macro 'TRILOGY_SERVER_STATUS'
    XX(TRILOGY_SERVER_STATUS_SESSION_STATE_CHANGED, 0x4000)
    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
../../../../ext/trilogy-ruby/cext.c:930:62: note: expanded from macro 'XX'
                                             ~~~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~
/opt/rubies/3.1.0/include/ruby-3.1.0/ruby/internal/symbol.h:329:18: note: expanded from macro 'rb_intern'
     (rb_intern)(str))
                 ^~~
../../../../ext/trilogy-ruby/cext.c:931:27: note: use array indexing to silence this warning
42 warnings generated.
```