### PR TITLE
Refactor error classes

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cast.c
+++ b/contrib/ruby/ext/trilogy-ruby/cast.c
@@ -71,7 +71,7 @@ static void cstr_from_value(char *buf, const trilogy_value_t *value, const char 
 {
 
     if (value->data_len > CAST_STACK_SIZE - 1) {
-        rb_raise(rb_cTrilogyError, errmsg, (int)value->data_len, (char *)value->data);
+        rb_raise(Trilogy_CastError, errmsg, (int)value->data_len, (char *)value->data);
     }
 
     memcpy(buf, value->data, value->data_len);
@@ -160,7 +160,7 @@ rb_trilogy_cast_value(const trilogy_value_t *value, const struct column_info *co
             double dbl = strtod(cstr, &err);
 
             if (*err != 0) {
-                rb_raise(rb_cTrilogyError, "Invalid double value: %.*s", (int)value->data_len, (char *)value->data);
+                rb_raise(Trilogy_CastError, "Invalid double value: %.*s", (int)value->data_len, (char *)value->data);
             }
             return rb_float_new(dbl);
         }
@@ -184,7 +184,7 @@ rb_trilogy_cast_value(const trilogy_value_t *value, const struct column_info *co
             }
 
             if (month < 1 || day < 1) {
-                rb_raise(rb_cTrilogyError, "Invalid date: %.*s", (int)value->data_len, (char *)value->data);
+                rb_raise(Trilogy_CastError, "Invalid date: %.*s", (int)value->data_len, (char *)value->data);
             }
 
             // pad out msec_char with zeroes at the end as it could be at any
@@ -215,7 +215,7 @@ rb_trilogy_cast_value(const trilogy_value_t *value, const struct column_info *co
             }
 
             if (month < 1 || day < 1) {
-                rb_raise(rb_cTrilogyError, "Invalid date: %.*s", (int)value->data_len, (char *)value->data);
+                rb_raise(Trilogy_CastError, "Invalid date: %.*s", (int)value->data_len, (char *)value->data);
             }
 
             return rb_funcall(Date, id_new, 3, INT2NUM(year), INT2NUM(month), INT2NUM(day));

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -21,7 +21,7 @@ static ID id_socket, id_host, id_port, id_username, id_password, id_found_rows, 
     id_write_timeout, id_keepalive_enabled, id_keepalive_idle, id_keepalive_interval, id_keepalive_count,
     id_ivar_affected_rows, id_ivar_fields, id_ivar_last_insert_id, id_ivar_rows, id_ivar_query_time, id_password,
     id_database, id_ssl_ca, id_ssl_capath, id_ssl_cert, id_ssl_cipher, id_ssl_crl, id_ssl_crlpath, id_ssl_key,
-    id_ssl_mode, id_tls_ciphersuites, id_tls_min_version, id_tls_max_version, id_multi_statement;
+    id_ssl_mode, id_tls_ciphersuites, id_tls_min_version, id_tls_max_version, id_multi_statement, id_from_code;
 
 struct trilogy_ctx {
     trilogy_conn_t conn;
@@ -91,12 +91,7 @@ static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *ms
 
     case TRILOGY_ERR: {
         VALUE message = rb_str_new(ctx->conn.error_message, ctx->conn.error_message_len);
-        VALUE exc = rb_exc_new3(Trilogy_ProtocolError,
-                                rb_sprintf("%" PRIsVALUE ": %d %" PRIsVALUE, rbmsg, ctx->conn.error_code, message));
-
-        rb_ivar_set(exc, rb_intern("@error_code"), INT2FIX(ctx->conn.error_code));
-        rb_ivar_set(exc, rb_intern("@error_message"), message);
-
+        VALUE exc = rb_funcall(Trilogy_ProtocolError, id_from_code, 2, message, INT2NUM(ctx->conn.error_code));
         rb_exc_raise(exc);
     }
 
@@ -1035,7 +1030,7 @@ void Init_cext()
     id_tls_min_version = rb_intern("tls_min_version");
     id_tls_max_version = rb_intern("tls_max_version");
     id_multi_statement = rb_intern("multi_statement");
-
+    id_from_code = rb_intern("from_code");
     id_ivar_affected_rows = rb_intern("@affected_rows");
     id_ivar_fields = rb_intern("@fields");
     id_ivar_last_insert_id = rb_intern("@last_insert_id");

--- a/contrib/ruby/ext/trilogy-ruby/trilogy-ruby.h
+++ b/contrib/ruby/ext/trilogy-ruby/trilogy-ruby.h
@@ -26,7 +26,7 @@ struct column_info {
     uint8_t decimals;
 };
 
-extern VALUE rb_cTrilogyError;
+extern VALUE Trilogy_CastError;
 
 VALUE
 rb_trilogy_cast_value(const trilogy_value_t *value, const struct column_info *column,

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -14,6 +14,18 @@ class Trilogy
 
   class BaseError < StandardError
     include Error
+
+    attr_reader :error_code
+
+    def initialize(error_message = nil, error_code = nil)
+      message = error_code ? "#{error_code}: #{error_message}" : error_message
+      super(message)
+      @error_code = error_code
+    end
+  end
+
+  class BaseConnectionError < BaseError
+    include ConnectionError
   end
 
   # Trilogy::ClientError is the base error type for invalid queries or parameters
@@ -28,41 +40,38 @@ class Trilogy
   class CastError < ClientError
   end
 
-
   class TimeoutError < Errno::ETIMEDOUT
     include ConnectionError
+
+    attr_reader :error_code
+
+    def initialize(error_message = nil, error_code = nil)
+      super
+      @error_code = error_code
+    end
   end
 
   class ProtocolError < BaseError
     ERROR_CODES = {
       1205 => TimeoutError, # ER_LOCK_WAIT_TIMEOUT
-      1044 => ConnectionError, # ER_DBACCESS_DENIED_ERROR
-      1045 => ConnectionError, # ER_ACCESS_DENIED_ERROR
-      1152 => ConnectionError, # ER_ABORTING_CONNECTION
-      1153 => ConnectionError, # ER_NET_PACKET_TOO_LARGE
-      1154 => ConnectionError, # ER_NET_READ_ERROR_FROM_PIPE
-      1155 => ConnectionError, # ER_NET_FCNTL_ERROR
-      1156 => ConnectionError, # ER_NET_PACKETS_OUT_OF_ORDER
-      1157 => ConnectionError, # ER_NET_UNCOMPRESS_ERROR
-      1158 => ConnectionError, # ER_NET_READ_ERROR
-      1159 => ConnectionError, # ER_NET_READ_INTERRUPTED
-      1160 => ConnectionError, # ER_NET_ERROR_ON_WRITE
-      1161 => ConnectionError, # ER_NET_WRITE_INTERRUPTED
-      1927 => ConnectionError, # ER_CONNECTION_KILLED
+      1044 => BaseConnectionError, # ER_DBACCESS_DENIED_ERROR
+      1045 => BaseConnectionError, # ER_ACCESS_DENIED_ERROR
+      1152 => BaseConnectionError, # ER_ABORTING_CONNECTION
+      1153 => BaseConnectionError, # ER_NET_PACKET_TOO_LARGE
+      1154 => BaseConnectionError, # ER_NET_READ_ERROR_FROM_PIPE
+      1155 => BaseConnectionError, # ER_NET_FCNTL_ERROR
+      1156 => BaseConnectionError, # ER_NET_PACKETS_OUT_OF_ORDER
+      1157 => BaseConnectionError, # ER_NET_UNCOMPRESS_ERROR
+      1158 => BaseConnectionError, # ER_NET_READ_ERROR
+      1159 => BaseConnectionError, # ER_NET_READ_INTERRUPTED
+      1160 => BaseConnectionError, # ER_NET_ERROR_ON_WRITE
+      1161 => BaseConnectionError, # ER_NET_WRITE_INTERRUPTED
+      1927 => BaseConnectionError, # ER_CONNECTION_KILLED
     }
-
-    attr_reader :error_code, :error_message
-
     class << self
       def from_code(message, code)
         ERROR_CODES.fetch(code, self).new(message, code)
       end
-    end
-
-    def initialize(error_message, error_code)
-      super("#{error_code}: #{error_message}")
-      @error_code = error_code
-      @error_message = error_message
     end
   end
 

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -178,7 +178,7 @@ class ClientTest < TrilogyTest
 
     _rs1 = client.query("SELECT id, int_test FROM trilogy_test; SELECT non_existent_column FROM trilogy_test")
 
-    assert_raises(Trilogy::DatabaseError) do
+    assert_raises(Trilogy::ProtocolError) do
       client.next_result
     end
   end
@@ -514,7 +514,7 @@ class ClientTest < TrilogyTest
   def test_database_error
     client = new_tcp_client
 
-    err = assert_raises Trilogy::DatabaseError do
+    err = assert_raises Trilogy::ProtocolError do
       client.query("not legit sqle")
     end
 
@@ -642,7 +642,7 @@ class ClientTest < TrilogyTest
       write_side.close
     end
 
-    ex = assert_raises Trilogy::DatabaseError do
+    ex = assert_raises Trilogy::ProtocolError do
       new_tcp_client(host: "127.0.0.1", port: fake_port)
     end
 
@@ -657,7 +657,7 @@ class ClientTest < TrilogyTest
 
     connection_id = client.query("SELECT CONNECTION_ID()").to_a.first.first
 
-    assert_raises Trilogy::DatabaseError do
+    assert_raises Trilogy::ProtocolError do
       client.query("SELECT /*+ MAX_EXECUTION_TIME(10) */ WAIT_FOR_EXECUTED_GTID_SET('01e4737c-9752-11e8-a17a-d40393d98615:1-76747', 1.01)")
     end
 

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -518,14 +518,17 @@ class ClientTest < TrilogyTest
     create_test_table(client_1)
     client_2.change_db("test")
 
-    client_1.query("SET GLOBAL innodb_lock_wait_timeout = 2;")
     client_1.query("INSERT INTO trilogy_test (varchar_test) VALUES ('a')")
     client_1.query("BEGIN")
     client_1.query("SELECT * FROM trilogy_test FOR UPDATE")
 
+    client_2.query("SET SESSION innodb_lock_wait_timeout = 1;")
     assert_raises Trilogy::TimeoutError do
       client_2.query("SELECT * FROM trilogy_test FOR UPDATE")
     end
+  ensure
+    ensure_closed(client_1)
+    ensure_closed(client_2)
   end
 
   def test_connection_error

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -528,6 +528,14 @@ class ClientTest < TrilogyTest
     end
   end
 
+  def test_connection_error
+    err = assert_raises Trilogy::BaseConnectionError do
+      new_tcp_client(username: "foo")
+    end
+
+    assert_includes err.message, "Access denied for user 'foo'"
+  end
+
   def test_database_error
     client = new_tcp_client
 

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -511,6 +511,23 @@ class ClientTest < TrilogyTest
     end
   end
 
+  def test_timeout_error
+    client_1 = new_tcp_client
+    client_2 = new_tcp_client
+
+    create_test_table(client_1)
+    client_2.change_db("test")
+
+    client_1.query("SET GLOBAL innodb_lock_wait_timeout = 2;")
+    client_1.query("INSERT INTO trilogy_test (varchar_test) VALUES ('a')")
+    client_1.query("BEGIN")
+    client_1.query("SELECT * FROM trilogy_test FOR UPDATE")
+
+    assert_raises Trilogy::TimeoutError do
+      client_2.query("SELECT * FROM trilogy_test FOR UPDATE")
+    end
+  end
+
   def test_database_error
     client = new_tcp_client
 

--- a/contrib/ruby/test/test_helper.rb
+++ b/contrib/ruby/test/test_helper.rb
@@ -7,6 +7,12 @@ require "minitest/autorun"
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 $LOAD_PATH.unshift File.expand_path("../", __FILE__)
 
+if GC.respond_to?(:verify_compaction_references)
+  # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
+  # move objects around, helping to find object movement bugs.
+  GC.verify_compaction_references(double_heap: true, toward: :empty)
+end
+
 class TrilogyTest < Minitest::Test
   DEFAULT_HOST = ENV["MYSQL_HOST"] || "127.0.0.1"
   DEFAULT_PORT = (port = ENV["MYSQL_PORT"].to_i) && port != 0 ? port : 3306


### PR DESCRIPTION
Fix: https://github.com/github/trilogy/issues/11

Opening this as a draft because I hit a few roadblocks, so I figured I should solicit some feedback.

The goals are:

  - Not raise any error that isn't a descendant of `Trilogy::Error`.
  - Have a clear distinction between transient network errors that may be retried, and invalid queries that shouldn't.

Unsolved issues (yet)

  - Trilogy calls `rb_syserr_fail_str` in a few places. Meaning it can still raise any of the `Errno::*` errors.
  - `handle_trilogy_error` raise all `TRILOGY_ERR` as `ProtocolError` which is a `ConnectionError`, but
     I'm not certain none of the possible errors could be considered client errors.

cc @composerinteralia @matthewd 