### PR TITLE
Include more post-query info on Result

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -21,9 +21,9 @@ static VALUE Trilogy_DatabaseError, Trilogy_Result;
 
 static ID id_socket, id_host, id_port, id_username, id_password, id_found_rows, id_connect_timeout, id_read_timeout,
     id_write_timeout, id_keepalive_enabled, id_keepalive_idle, id_keepalive_interval, id_keepalive_count,
-    id_ivar_fields, id_ivar_rows, id_ivar_query_time, id_password, id_database, id_ssl_ca, id_ssl_capath, id_ssl_cert,
-    id_ssl_cipher, id_ssl_crl, id_ssl_crlpath, id_ssl_key, id_ssl_mode, id_tls_ciphersuites, id_tls_min_version,
-    id_tls_max_version;
+    id_ivar_affected_rows, id_ivar_fields, id_ivar_last_insert_id, id_ivar_rows, id_ivar_query_time, id_password,
+    id_database, id_ssl_ca, id_ssl_capath, id_ssl_cert, id_ssl_cipher, id_ssl_crl, id_ssl_crlpath, id_ssl_key,
+    id_ssl_mode, id_tls_ciphersuites, id_tls_min_version, id_tls_max_version;
 
 struct trilogy_ctx {
     trilogy_conn_t conn;
@@ -606,6 +606,10 @@ static VALUE execute_read_query(VALUE vargs)
     rb_ivar_set(result, id_ivar_query_time, DBL2NUM(query_time));
 
     if (rc == TRILOGY_OK) {
+        rb_ivar_set(result, id_ivar_last_insert_id, ULL2NUM(ctx->conn.last_insert_id));
+
+        rb_ivar_set(result, id_ivar_affected_rows, ULL2NUM(ctx->conn.affected_rows));
+
         return result;
     }
 
@@ -894,7 +898,9 @@ void Init_cext()
     Trilogy_Result = rb_define_class_under(Trilogy, "Result", rb_cObject);
     rb_global_variable(&Trilogy_Result);
 
+    rb_define_attr(Trilogy_Result, "affected_rows", 1, 0);
     rb_define_attr(Trilogy_Result, "fields", 1, 0);
+    rb_define_attr(Trilogy_Result, "last_insert_id", 1, 0);
     rb_define_attr(Trilogy_Result, "rows", 1, 0);
     rb_define_attr(Trilogy_Result, "query_time", 1, 0);
 
@@ -924,7 +930,9 @@ void Init_cext()
     id_tls_min_version = rb_intern("tls_min_version");
     id_tls_max_version = rb_intern("tls_max_version");
 
+    id_ivar_affected_rows = rb_intern("@affected_rows");
     id_ivar_fields = rb_intern("@fields");
+    id_ivar_last_insert_id = rb_intern("@last_insert_id");
     id_ivar_rows = rb_intern("@rows");
     id_ivar_query_time = rb_intern("@query_time");
 

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -153,9 +153,20 @@ class ClientTest < TrilogyTest
     create_test_table(client)
 
     client.query "TRUNCATE trilogy_test"
-    result = client.query "INSERT INTO trilogy_test (varchar_test) VALUES ('a')"
-    assert result
+    result_a = client.query "INSERT INTO trilogy_test (varchar_test) VALUES ('a')"
+    assert result_a
     assert_equal 1, client.last_insert_id
+
+    result_b = client.query "INSERT INTO trilogy_test (varchar_test) VALUES ('b')"
+    assert result_b
+    assert_equal 2, client.last_insert_id
+
+    result_select = client.query("SELECT varchar_test FROM trilogy_test")
+    assert_equal 0, client.last_insert_id
+
+    assert_equal 1, result_a.last_insert_id
+    assert_equal 2, result_b.last_insert_id
+    assert_nil result_select.last_insert_id
   ensure
     ensure_closed client
   end
@@ -166,11 +177,18 @@ class ClientTest < TrilogyTest
 
     client.query("INSERT INTO trilogy_test (varchar_test, int_test) VALUES ('a', 1)")
 
-    client.query("UPDATE trilogy_test SET int_test = 1 WHERE varchar_test = 'a'")
+    result_unchanged = client.query("UPDATE trilogy_test SET int_test = 1 WHERE varchar_test = 'a'")
     assert_equal 0, client.affected_rows
 
-    client.query("UPDATE trilogy_test SET int_test = 2 WHERE varchar_test = 'a'")
+    result_changed = client.query("UPDATE trilogy_test SET int_test = 2 WHERE varchar_test = 'a'")
     assert_equal 1, client.affected_rows
+
+    result_select = client.query("SELECT int_test FROM trilogy_test WHERE varchar_test = 'a'")
+    assert_equal 0, client.affected_rows
+
+    assert_equal 0, result_unchanged.affected_rows
+    assert_equal 1, result_changed.affected_rows
+    assert_nil result_select.affected_rows
   ensure
     ensure_closed client
   end
@@ -181,11 +199,18 @@ class ClientTest < TrilogyTest
 
     client.query("INSERT INTO trilogy_test (varchar_test, int_test) VALUES ('a', 1)")
 
-    client.query("UPDATE trilogy_test SET int_test = 1 WHERE varchar_test = 'a'")
+    result_unchanged = client.query("UPDATE trilogy_test SET int_test = 1 WHERE varchar_test = 'a'")
     assert_equal 1, client.affected_rows
 
-    client.query("UPDATE trilogy_test SET int_test = 2 WHERE varchar_test = 'a'")
+    result_changed = client.query("UPDATE trilogy_test SET int_test = 2 WHERE varchar_test = 'a'")
     assert_equal 1, client.affected_rows
+
+    result_select = client.query("SELECT int_test FROM trilogy_test WHERE varchar_test = 'a'")
+    assert_equal 0, client.affected_rows
+
+    assert_equal 1, result_unchanged.affected_rows
+    assert_equal 1, result_changed.affected_rows
+    assert_nil result_select.affected_rows
   ensure
     ensure_closed client
   end


### PR DESCRIPTION
Instead of leaving the caller to read `last_insert_id` and `affected_rows` from the connection before they're overwritten, let's copy them to the returned Result object.

While the connection always returns integers for those values (`0` when they're N/A), it seems more reasonable to assume callers anticipate the shape of their particular result, so here I'm instead preferring to return `nil` on results for queries where these don't apply. (As a side-effect this allows a caller to distinguish a zero-row-returning SELECT (`rows == []`, `affected_rows == nil`) from a zero-row-affecting UPDATE (`rows == []`, `affected_rows == 0`). I'm not sure where that might be specifically useful, but it seems nice to have?)