### PR TITLE
Remove BUNDLED_WITH

### DIFF
--- a/contrib/ruby/Gemfile.lock
+++ b/contrib/ruby/Gemfile.lock
@@ -22,6 +22,3 @@ DEPENDENCIES
   mysql2
   rake-compiler (~> 1.0)
   trilogy!
-
-BUNDLED WITH
-   2.3.4


### PR DESCRIPTION
I accidentally broke CI by adding BUNDLED_WITH. At some point we should
probably run against a later version of Ruby and bundler, but I'll do
this for now to get things passing quickly without needing to mess
around with the Dockerfiles, etc.