### PR TITLE
Don't scramble passwords when responding to auth switch request

### DIFF
--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -26,6 +26,13 @@ class ClientTest < TrilogyTest
     end
   end
 
+  def test_trilogy_connect_with_native_password_auth_switch
+    client = new_tcp_client username: "native"
+    refute_nil client
+  ensure
+    ensure_closed client
+  end
+
   def test_trilogy_connect_tcp_fixnum_port
     assert_raises TypeError do
       new_tcp_client port: "13306"

--- a/docker-entrypoint-initdb.d/native_password_user.sql
+++ b/docker-entrypoint-initdb.d/native_password_user.sql
@@ -1,0 +1,3 @@
+CREATE USER 'native'@'%';
+GRANT ALL PRIVILEGES ON test.* TO 'native'@'%';
+ALTER USER 'native'@'%' IDENTIFIED WITH mysql_native_password BY '';

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -579,10 +579,12 @@ int trilogy_build_auth_switch_response_packet(trilogy_builder_t *builder, const 
     unsigned int auth_response_len = 0;
     uint8_t auth_response[EVP_MAX_MD_SIZE];
 
-    if (!strcmp("caching_sha2_password", auth_plugin)) {
-        trilogy_pack_scramble_sha2_hash(scramble, pass, pass_len, auth_response, &auth_response_len);
-    } else {
-        trilogy_pack_scramble_native_hash(scramble, pass, pass_len, auth_response, &auth_response_len);
+    if (pass_len > 0) {
+        if (!strcmp("caching_sha2_password", auth_plugin)) {
+            trilogy_pack_scramble_sha2_hash(scramble, pass, pass_len, auth_response, &auth_response_len);
+        } else {
+            trilogy_pack_scramble_native_hash(scramble, pass, pass_len, auth_response, &auth_response_len);
+        }
     }
 
     CHECKED(trilogy_builder_write_buffer(builder, auth_response, auth_response_len));


### PR DESCRIPTION
While testing trilogy against mysql8 I discovered a bug in our auth switching logic: when the password length is `0` we shouldn't be sending a password scramble to the server to authenticate the user. For initial authentication we check the password length, but in the `trilogy_build_auth_switch_response_packet` function we didn't and always scrambled the password.

## Reproduction

To reproduce this bug, two things have to be true:

1. The user's password must be blank (empty string)
2. The authentication plugin set for the user must be _different_ to the default plugin for the server

In mysql 8 the default plugin changed from `mysql_native_password` to `caching_sha2_password`. Even though our tests test with empty strings for passwords, that wasn't enough to trigger the bug because the users we create always have the same auth plugin as the server default.

## Testing

To reproduce and test this, I have added a user that has the `mysql_native_password` plugin set explicitly. In mysql 8 this will be different to the server default and so triggers the bug as shown in [e55f584](https://github.com/github/trilogy/pull/21/commits/e55f584bd6354c6c777130d61541dbdeb081ae03).

Unfortunately this doesn't test the bug against mysql 5.7, as the default there is also `mysql_native_password`, so the edge cases is not triggered. However I'm not sure we _can_ test this against 5.7 as I don't believe 5.7 supports `caching_sha2_password` server side, and trilogy client doesn't support any other plugins.

## Questions

I haven't added any tests in `c` as honestly I don't know c very well, and I couldn't work out if/how auth switching is tested there. I'd appreciate guidance if tests for this should be added.