### PR TITLE
MariaDB fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ TEST_SOURCES = $(shell find test -name '*.c')
 OBJS = $(SOURCES:.c=.o)
 FUZZ_OBJ = test/fuzz.o
 
-CFLAGS ?= -O1
+CFLAGS ?= -O1 -ggdb3
 CFLAGS += -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=2 -fstack-protector
 CFLAGS += -Wall -Werror -Wextra -pedantic -Wsign-conversion -Wno-missing-field-initializers -std=gnu99 -iquote inc
 

--- a/src/protocol.c
+++ b/src/protocol.c
@@ -261,16 +261,7 @@ int trilogy_parse_handshake_packet(const uint8_t *buff, size_t len, trilogy_hand
     // This space is reserved. It should be all NULL bytes but some tools or
     // future versions of MySQL-compatible clients may use it. This library
     // opts to skip the validation as some servers don't respect the protocol.
-    //
-    static const uint8_t null_filler[10] = {0};
-
-    const void *str;
-    CHECKED(trilogy_reader_get_buffer(&reader, 10, &str));
-
-    if (memcmp(str, null_filler, 10) != 0) {
-        // corrupt handshake packet
-        return TRILOGY_PROTOCOL_VIOLATION;
-    }
+    CHECKED(trilogy_reader_get_buffer(&reader, 10, NULL));
 
     if (out_packet->capabilities & TRILOGY_CAPABILITIES_SECURE_CONNECTION && auth_data_len > 8) {
         uint8_t remaining_auth_data_len = auth_data_len - 8;

--- a/test/blocking_test.c
+++ b/test/blocking_test.c
@@ -87,7 +87,7 @@ TEST test_blocking_query()
     ASSERT_EQ(0, column.original_name_len);
     ASSERT_EQ(TRILOGY_CHARSET_BINARY, column.charset);
     ASSERT(column.len == 1 || column.len == 2);
-    ASSERT_EQ(TRILOGY_TYPE_LONGLONG, column.type);
+    ASSERT(column.type == TRILOGY_TYPE_LONGLONG || column.type == TRILOGY_TYPE_LONG);
     ASSERT(column.flags & TRILOGY_COLUMN_FLAG_BINARY);
     ASSERT(column.flags & TRILOGY_COLUMN_FLAG_NOT_NULL);
     ASSERT_EQ(0, column.decimals);

--- a/test/protocol/parsing/handshake_test.c
+++ b/test/protocol/parsing/handshake_test.c
@@ -121,7 +121,7 @@ TEST test_parse_handshake_invalid_null_filler()
     PASS();
 }
 
-TEST test_parse_handshake_invalid_long_null_filler()
+TEST test_parse_handshake_ignores_reserved_filler()
 {
     uint8_t handshake_packet[sizeof(valid_handshake_packet)];
     memcpy(handshake_packet, valid_handshake_packet, sizeof(valid_handshake_packet));
@@ -130,7 +130,7 @@ TEST test_parse_handshake_invalid_long_null_filler()
 
     handshake_packet[29] = 0xff;
     int err = trilogy_parse_handshake_packet(handshake_packet, sizeof(handshake_packet), &packet);
-    ASSERT_ERR(TRILOGY_PROTOCOL_VIOLATION, err);
+    ASSERT_OK(err);
 
     PASS();
 }
@@ -143,7 +143,7 @@ int parse_handshake_test()
     RUN_TEST(test_parse_handshake_no_protocol41_flag);
     RUN_TEST(test_parse_handshake_no_secure_connection_flag);
     RUN_TEST(test_parse_handshake_invalid_null_filler);
-    RUN_TEST(test_parse_handshake_invalid_long_null_filler);
+    RUN_TEST(test_parse_handshake_ignores_reserved_filler);
 
     return 0;
 }

--- a/test/protocol/parsing/handshake_test.c
+++ b/test/protocol/parsing/handshake_test.c
@@ -99,8 +99,8 @@ TEST test_parse_handshake_no_secure_connection_flag()
 
     trilogy_handshake_t packet;
 
-    handshake_packet[21] &= ~TRILOGY_CAPABILITIES_SECURE_CONNECTION;
-    handshake_packet[22] &= ~(TRILOGY_CAPABILITIES_SECURE_CONNECTION >> 8);
+    handshake_packet[21] &= (~TRILOGY_CAPABILITIES_SECURE_CONNECTION) & 0xff;
+    handshake_packet[22] &= ((~TRILOGY_CAPABILITIES_SECURE_CONNECTION) >> 8) & 0xff;
     int err = trilogy_parse_handshake_packet(handshake_packet, sizeof(handshake_packet), &packet);
     ASSERT_ERR(TRILOGY_PROTOCOL_VIOLATION, err);
 


### PR DESCRIPTION
As a comment already suggested, some servers do use the 10 reserved bytes in the server handshake packet, specifically MariaDB 10.2+. It should be safe to ignore, which allows connecting to MariaDB.