### PR TITLE
Ruby test suite improvements

### DIFF
--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -36,6 +36,8 @@ jobs:
         brew services start mysql@${{ matrix.mysql }}
         sleep 5
         $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot -e 'CREATE DATABASE test'
+        $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot < docker-entrypoint-initdb.d/native_password_user.sql
+        $(brew --prefix mysql@${{ matrix.mysql }})/bin/mysql -uroot < docker-entrypoint-initdb.d/x509_user.sql
     - name: Install dependencies
       run: |
         cd contrib/ruby

--- a/contrib/ruby/Rakefile
+++ b/contrib/ruby/Rakefile
@@ -1,5 +1,6 @@
 require "bundler/gem_tasks"
 require "rake/extensiontask"
+require "rake/testtask"
 
 Rake::ExtensionTask.new do |ext|
   ext.name  = "cext"
@@ -7,9 +8,12 @@ Rake::ExtensionTask.new do |ext|
   ext.lib_dir = "lib/trilogy"
 end
 
-task :test => :compile do
-  system('script/test')
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/*_test.rb']
+  t.verbose = true
 end
+task :test => :compile
 
 task :default => :test
 

--- a/contrib/ruby/script/test
+++ b/contrib/ruby/script/test
@@ -3,8 +3,4 @@ set -e
 cd "$(dirname "$0")/.."
 
 # run entire test suite
-exec ruby \
-    -r "$(pwd)/test/setup" \
-    -e "ARGV.each { |f| require(f) }" \
-    -v \
-    -- ${*:-`find $(pwd)/test -name '*_test.rb'`}
+bundle exec rake test

--- a/contrib/ruby/test/cast_test.rb
+++ b/contrib/ruby/test/cast_test.rb
@@ -1,6 +1,4 @@
-require File.expand_path("../setup", __FILE__)
-
-require "trilogy"
+require "test_helper"
 
 class CastTest < TrilogyTest
   def setup

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -1,7 +1,4 @@
-require File.expand_path("../setup", __FILE__)
-
-require "trilogy"
-require "timeout"
+require "test_helper"
 
 class ClientTest < TrilogyTest
   def test_trilogy_connected_host

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -414,7 +414,7 @@ class ClientTest < TrilogyTest
   end
 
   def test_timeout_deadlines
-    assert_elapsed(0.1, 0.03) do
+    assert_elapsed(0.1, 0.3) do
       client = new_tcp_client
 
       assert_raises Timeout::Error do

--- a/contrib/ruby/test/ssl_test.rb
+++ b/contrib/ruby/test/ssl_test.rb
@@ -1,4 +1,4 @@
-require File.expand_path("../setup", __FILE__)
+require "test_helper"
 
 require "openssl"
 require "trilogy"

--- a/contrib/ruby/test/test_helper.rb
+++ b/contrib/ruby/test/test_helper.rb
@@ -1,9 +1,7 @@
-require "rubygems" if !defined?(Gem)
-require "bundler/setup"
+require "trilogy"
 require "socket"
 require "timeout"
 
-require "timeout"
 require "minitest/autorun"
 
 $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,6 @@ services:
       dockerfile: "${DOCKERFILE}"
     environment:
       MYSQL_HOST: db.local
-      MYSQL_VERSION: ${MYSQL_VERSION}
       TRILOGY_TEST_CERTS: "/db-data"
     depends_on:
       - db

--- a/script/cibuild
+++ b/script/cibuild
@@ -43,5 +43,6 @@ trap cleanup EXIT
 
 export CI_MODE=true
 
+docker-compose rm -s -f -v
 output_fold "Bootstrapping container..." docker-compose build
 output_fold "Running tests..." docker-compose run --rm app


### PR DESCRIPTION
Some small improvements to make the test suite easier to use and more reliable.

* Instead of checking and guessing based on `MYSQL_VERSION`, query the database for supported TLS versions. This should be more accurate as some 5.7 images now behave the way the tests previously expected 8 to (previously they unnecessarily skipped some tests)
* Use `rake test` instead of a custom `script/test` script
* Rename test/setup.rb to test/test_helper.rb