### PR TITLE
Remove unused constant TRILOGY_MAX_PROTO_PACKET_LEN

### DIFF
--- a/inc/trilogy/builder.h
+++ b/inc/trilogy/builder.h
@@ -26,7 +26,7 @@ typedef struct {
  * buffer  - A pre-initialized trilogy_buffer_t pointer
  * seq     - The initial sequence number for the packet to be built. This is
  *           the initial number because the builder API will automatically
- *           split buffers that are larger than TRILOGY_MAX_PROTO_PACKET_LEN into
+ *           split buffers that are larger than TRILOGY_MAX_PACKET_LEN into
  *           multiple packets and increment the sequence number in each packet
  *           following the initial.
  *

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -370,11 +370,6 @@ typedef enum {
 #undef XX
 } TRILOGY_COLUMN_FLAG_t;
 
-/*
- * Data between client and server is exchanged in packets of max 16MByte size.
- */
-#define TRILOGY_MAX_PROTO_PACKET_LEN 0xffffff
-
 // Typical response packet types
 typedef enum {
     TRILOGY_PACKET_OK = 0x0,


### PR DESCRIPTION
I was reading through the codebase and noticed a small discrepancy as I traced through the code. Current documentation refers to `TRILOGY_MAX_PROTO_PACKET_LEN` as the constant that informs segmenting packets etc., [but the code really makes use of `TRILOGY_MAX_PACKET_LEN`.](https://github.com/github/trilogy/search?q=TRILOGY_MAX_PACKET_LEN&type=code)

This constant was never used in code. This commit removes the constant and updates documentation to better reflect how the codebase actually operates.