### PR TITLE
Add #closed? method to Trilogy client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+  - Add `#closed?` method to Ruby binding. #30
+
 ## 2.1.2
 
 2022-10-04

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -826,6 +826,17 @@ static VALUE rb_trilogy_close(VALUE self)
     return Qnil;
 }
 
+static VALUE rb_trilogy_closed(VALUE self)
+{
+    struct trilogy_ctx *ctx = get_ctx(self);
+
+    if (ctx->conn.socket == NULL) {
+        return Qtrue;
+    } else {
+        return Qfalse;
+    }
+}
+
 static VALUE rb_trilogy_last_insert_id(VALUE self) { return ULL2NUM(get_open_ctx(self)->conn.last_insert_id); }
 
 static VALUE rb_trilogy_affected_rows(VALUE self) { return ULL2NUM(get_open_ctx(self)->conn.affected_rows); }
@@ -897,6 +908,7 @@ void Init_cext()
     rb_define_method(Trilogy, "ping", rb_trilogy_ping, 0);
     rb_define_method(Trilogy, "escape", rb_trilogy_escape, 1);
     rb_define_method(Trilogy, "close", rb_trilogy_close, 0);
+    rb_define_method(Trilogy, "closed?", rb_trilogy_closed, 0);
     rb_define_method(Trilogy, "last_insert_id", rb_trilogy_last_insert_id, 0);
     rb_define_method(Trilogy, "affected_rows", rb_trilogy_affected_rows, 0);
     rb_define_method(Trilogy, "warning_count", rb_trilogy_warning_count, 0);

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -283,6 +283,18 @@ class ClientTest < TrilogyTest
     ensure_closed client
   end
 
+  def test_trilogy_closed?
+    client = new_tcp_client
+
+    refute_predicate client, :closed?
+
+    client.close
+
+    assert_predicate client, :closed?
+  ensure
+    ensure_closed client
+  end
+
   def test_read_timeout
     client = new_tcp_client(read_timeout: 0.1)
 


### PR DESCRIPTION
This PR extends the API available on the Ruby bindings to include a `#closed?` predicate method. It's use-case is inspired by the ongoing work to introduce a [Semian adapter for Trilogy](https://github.com/Shopify/semian/pull/420).

It uses the presence of the `conn.socket` to make the conclusion of whether the connection is currently closed or opened—this is the same condition that `rb_trilogy_close` uses to determine whether or not to initiate a close request, so I'd assume it's sufficient. Open to hearing feedback on this, though.