### PR TITLE
ruby: Use TypedData_* APIs

### DIFF
--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -638,4 +638,10 @@ class ClientTest < TrilogyTest
     end
     assert_equal "trilogy_connect - unable to connect to mysql.invalid:3306: TRILOGY_DNS_ERR", ex.message
   end
+
+  def test_memsize
+    require 'objspace'
+    client = new_tcp_client
+    assert_kind_of Integer, ObjectSpace.memsize_of(client)
+  end
 end


### PR DESCRIPTION
The `Data_*` API still works, and AFAIK are not officially deprecated but they're certainly no longer recommended.

In the context of trilogy the difference in implementation is very marginal.

As it doesn't hold onto any `VALUE` reference, it can register itself as write barrier protected, so it isn't marked on every minor GC runs.

cc @jhawthorn 