### PR TITLE
Fix memory leak

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -96,6 +96,7 @@ static void free_trilogy(struct trilogy_ctx *ctx)
     if (ctx->conn.socket != NULL) {
         trilogy_free(&ctx->conn);
     }
+    xfree(ctx);
 }
 
 static VALUE allocate_trilogy(VALUE klass)


### PR DESCRIPTION
@jhawthorn noticed that we weren't freeing the trilogy_ctx. I tested locally with:

```rb
#!/usr/bin/env ruby

require "bundler/setup"
require "trilogy"

1000000.times { GC.start; Trilogy.new(database: "test").close }
```

and can confirm that RSS climbs consistently before this patch, and does not climb once this patch is applied.