### PR TITLE
Cast to Integer when there are no decimals

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cast.c
+++ b/contrib/ruby/ext/trilogy-ruby/cast.c
@@ -142,10 +142,14 @@ rb_trilogy_cast_value(const trilogy_value_t *value, const struct column_info *co
         }
         case TRILOGY_TYPE_DECIMAL:
         case TRILOGY_TYPE_NEWDECIMAL: {
-            // TODO - optimize so we don't have to allocate a ruby string for
-            // decimal columns
-            VALUE str = rb_str_new(value->data, value->data_len);
-            return rb_funcall(rb_mKernel, id_BigDecimal, 1, str);
+            if (column->decimals == 0) {
+                return rb_cstr2inum(value->data, 10);
+            } else {
+                // TODO - optimize so we don't have to allocate a ruby string for
+                // decimal columns
+                VALUE str = rb_str_new(value->data, value->data_len);
+                return rb_funcall(rb_mKernel, id_BigDecimal, 1, str);
+            }
         }
         case TRILOGY_TYPE_FLOAT:
         case TRILOGY_TYPE_DOUBLE: {

--- a/contrib/ruby/ext/trilogy-ruby/cast.c
+++ b/contrib/ruby/ext/trilogy-ruby/cast.c
@@ -7,7 +7,7 @@
 
 #define CAST_STACK_SIZE 64
 
-static ID id_BigDecimal, id_new, id_local, id_localtime, id_utc;
+static ID id_BigDecimal, id_Integer, id_new, id_local, id_localtime, id_utc;
 
 static const char *ruby_encoding_name_map[] = {
     [TRILOGY_ENCODING_ARMSCII8] = NULL,
@@ -142,12 +142,12 @@ rb_trilogy_cast_value(const trilogy_value_t *value, const struct column_info *co
         }
         case TRILOGY_TYPE_DECIMAL:
         case TRILOGY_TYPE_NEWDECIMAL: {
+            // TODO - optimize so we don't have to allocate a ruby string for
+            // decimal columns
+            VALUE str = rb_str_new(value->data, value->data_len);
             if (column->decimals == 0) {
-                return rb_cstr2inum(value->data, 10);
+                return rb_funcall(rb_mKernel, id_Integer, 1, str);
             } else {
-                // TODO - optimize so we don't have to allocate a ruby string for
-                // decimal columns
-                VALUE str = rb_str_new(value->data, value->data_len);
                 return rb_funcall(rb_mKernel, id_BigDecimal, 1, str);
             }
         }
@@ -269,6 +269,7 @@ void rb_trilogy_cast_init(void)
     rb_require("date");
 
     id_BigDecimal = rb_intern("BigDecimal");
+    id_Integer = rb_intern("Integer");
     id_new = rb_intern("new");
     id_local = rb_intern("local");
     id_localtime = rb_intern("localtime");

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -667,6 +667,7 @@ static VALUE read_query_response(VALUE vargs)
         column_info[i].flags = column.flags;
         column_info[i].len = column.len;
         column_info[i].charset = column.charset;
+        column_info[i].decimals = column.decimals;
     }
 
     trilogy_value_t *row_values = ALLOC_N(trilogy_value_t, column_count);

--- a/contrib/ruby/ext/trilogy-ruby/trilogy-ruby.h
+++ b/contrib/ruby/ext/trilogy-ruby/trilogy-ruby.h
@@ -23,6 +23,7 @@ struct column_info {
     TRILOGY_CHARSET_t charset;
     uint32_t len;
     uint16_t flags;
+    uint8_t decimals;
 };
 
 extern VALUE rb_cTrilogyError;

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -725,11 +725,13 @@ class ClientTest < TrilogyTest
     client.query("INSERT INTO trilogy_test (int_test) VALUES ('1')")
 
     result = client.query("SELECT SUM(int_test) FROM trilogy_test")
-    assert result.rows[0][0].is_a?(Integer)
+    sum = result.rows[0][0]
+
+    assert sum.is_a?(Integer)
+    assert_equal 8, sum
   end
 
   def test_trilogy_decimal_sum_query
-    client = new_tcp_client
     client = new_tcp_client
     create_test_table(client)
 
@@ -738,6 +740,9 @@ class ClientTest < TrilogyTest
     client.query("INSERT INTO trilogy_test (decimal_test) VALUES ('1')")
 
     result = client.query("SELECT SUM(decimal_test) FROM trilogy_test")
-    assert result.rows[0][0].is_a?(BigDecimal)
+    sum = result.rows[0][0]
+
+    assert sum.is_a?(BigDecimal)
+    assert_equal 8, sum
   end
 end

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -715,4 +715,29 @@ class ClientTest < TrilogyTest
     client = new_tcp_client
     assert_kind_of Integer, ObjectSpace.memsize_of(client)
   end
+
+  def test_trilogy_int_sum_query
+    client = new_tcp_client
+    create_test_table(client)
+
+    client.query("INSERT INTO trilogy_test (int_test) VALUES ('4')")
+    client.query("INSERT INTO trilogy_test (int_test) VALUES ('3')")
+    client.query("INSERT INTO trilogy_test (int_test) VALUES ('1')")
+
+    result = client.query("SELECT SUM(int_test) FROM trilogy_test")
+    assert result.rows[0][0].is_a?(Integer)
+  end
+
+  def test_trilogy_decimal_sum_query
+    client = new_tcp_client
+    client = new_tcp_client
+    create_test_table(client)
+
+    client.query("INSERT INTO trilogy_test (decimal_test) VALUES ('4')")
+    client.query("INSERT INTO trilogy_test (decimal_test) VALUES ('3')")
+    client.query("INSERT INTO trilogy_test (decimal_test) VALUES ('1')")
+
+    result = client.query("SELECT SUM(decimal_test) FROM trilogy_test")
+    assert result.rows[0][0].is_a?(BigDecimal)
+  end
 end


### PR DESCRIPTION
Prior to this commit we'd always cast a SUM query to `BigDecimal`, since the column type we get from the server is 246 (i.e. TRILOGY_TYPE_NEWDECIMAL).

After this commit we'll only cast to `BigDecimal` if the column includes decimal digits. If there are none (i.e. if column->decimals is 0), we cast to `Integer` instead.

Closes https://github.com/github/trilogy/issues/36