### PR TITLE
Implement `#abandon_results!` for Ruby binding

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -764,6 +764,20 @@ static VALUE rb_trilogy_more_results_exist(VALUE self)
     }
 }
 
+static VALUE rb_trilogy_abandon_results(VALUE self)
+{
+    struct trilogy_ctx *ctx = get_open_ctx(self);
+
+    int count = 0;
+
+    while(ctx->conn.server_status & TRILOGY_SERVER_STATUS_MORE_RESULTS_EXISTS) {
+        VALUE result = execute_read_query_response(ctx);
+        count++;
+    }
+
+    return INT2NUM(count);
+}
+
 static VALUE rb_trilogy_query(VALUE self, VALUE query)
 {
     struct trilogy_ctx *ctx = get_open_ctx(self);
@@ -970,6 +984,7 @@ void Init_cext()
     rb_define_method(Trilogy, "server_version", rb_trilogy_server_version, 0);
     rb_define_method(Trilogy, "more_results_exist?", rb_trilogy_more_results_exist, 0);
     rb_define_method(Trilogy, "next_result", rb_trilogy_next_result, 0);
+    rb_define_method(Trilogy, "abandon_results!", rb_trilogy_abandon_results, 0);
     rb_define_const(Trilogy, "TLS_VERSION_10", INT2NUM(TRILOGY_TLS_VERSION_10));
     rb_define_const(Trilogy, "TLS_VERSION_11", INT2NUM(TRILOGY_TLS_VERSION_11));
     rb_define_const(Trilogy, "TLS_VERSION_12", INT2NUM(TRILOGY_TLS_VERSION_12));


### PR DESCRIPTION
#### What?

This PR adds a method for the Ruby binding: `#abandon_results!`

#### Why?

Following the introduction of multi-statement support (#35), a common pattern for clients is to discard the queue of result sets so as to put the client back into a usable state as quickly as possible. This is especially helpful when multi-statement is being used for bulk inserts, where the result sets aren't particularly relevant. This helper method simplifies that pattern.

#### Details

I opted to return a count signifying the number of results abandoned. I think this can be helpful and doubles as a non-zero success status.

#### Better compatibility with `mysql2`

This method exists on `mysql2` and serves the same purpose.