### PR TITLE
Error class refactoring (part 2)

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -15,7 +15,8 @@
 #define TRILOGY_RB_TIMEOUT 1
 
 VALUE Trilogy_CastError;
-static VALUE Trilogy_ProtocolError, Trilogy_Result, Trilogy_SSLError, Trilogy_QueryError, Trilogy_TimeoutError;
+static VALUE Trilogy_BaseConnectionError, Trilogy_ProtocolError, Trilogy_SSLError, Trilogy_QueryError,
+    Trilogy_TimeoutError, Trilogy_Result;
 
 static ID id_socket, id_host, id_port, id_username, id_password, id_found_rows, id_connect_timeout, id_read_timeout,
     id_write_timeout, id_keepalive_enabled, id_keepalive_idle, id_keepalive_interval, id_keepalive_count,
@@ -108,6 +109,10 @@ static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *ms
             trilogy_sock_shutdown(ctx->conn.socket);
         }
         rb_raise(Trilogy_SSLError, "%" PRIsVALUE ": SSL Error: %s", rbmsg, ERR_reason_error_string(ossl_error));
+    }
+
+    case TRILOGY_DNS_ERR: {
+        rb_raise(Trilogy_BaseConnectionError, "%" PRIsVALUE ": TRILOGY_DNS_ERROR", rbmsg);
     }
 
     default:
@@ -994,6 +999,9 @@ void Init_cext()
 
     Trilogy_TimeoutError = rb_const_get(Trilogy, rb_intern("TimeoutError"));
     rb_global_variable(&Trilogy_TimeoutError);
+
+    Trilogy_BaseConnectionError = rb_const_get(Trilogy, rb_intern("BaseConnectionError"));
+    rb_global_variable(&Trilogy_BaseConnectionError);
 
     Trilogy_Result = rb_const_get(Trilogy, rb_intern("Result"));
     rb_global_variable(&Trilogy_Result);

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -16,7 +16,7 @@
 
 VALUE Trilogy_CastError;
 static VALUE Trilogy_BaseConnectionError, Trilogy_ProtocolError, Trilogy_SSLError, Trilogy_QueryError,
-    Trilogy_TimeoutError, Trilogy_Result;
+    Trilogy_ConnectionClosedError, Trilogy_TimeoutError, Trilogy_Result;
 
 static ID id_socket, id_host, id_port, id_username, id_password, id_found_rows, id_connect_timeout, id_read_timeout,
     id_write_timeout, id_keepalive_enabled, id_keepalive_idle, id_keepalive_interval, id_keepalive_count,
@@ -71,7 +71,7 @@ static struct trilogy_ctx *get_open_ctx(VALUE obj)
     struct trilogy_ctx *ctx = get_ctx(obj);
 
     if (ctx->conn.socket == NULL) {
-        rb_raise(rb_eIOError, "connection closed");
+        rb_raise(Trilogy_ConnectionClosedError, "Attempted to use closed connection");
     }
 
     return ctx;
@@ -1002,6 +1002,9 @@ void Init_cext()
 
     Trilogy_BaseConnectionError = rb_const_get(Trilogy, rb_intern("BaseConnectionError"));
     rb_global_variable(&Trilogy_BaseConnectionError);
+
+    Trilogy_ConnectionClosedError = rb_const_get(Trilogy, rb_intern("ConnectionClosed"));
+    rb_global_variable(&Trilogy_ConnectionClosedError);
 
     Trilogy_Result = rb_const_get(Trilogy, rb_intern("Result"));
     rb_global_variable(&Trilogy_Result);

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -56,6 +56,7 @@ class Trilogy
       1205 => TimeoutError, # ER_LOCK_WAIT_TIMEOUT
       1044 => BaseConnectionError, # ER_DBACCESS_DENIED_ERROR
       1045 => BaseConnectionError, # ER_ACCESS_DENIED_ERROR
+      1064 => QueryError, # ER_PARSE_ERROR
       1152 => BaseConnectionError, # ER_ABORTING_CONNECTION
       1153 => BaseConnectionError, # ER_NET_PACKET_TOO_LARGE
       1154 => BaseConnectionError, # ER_NET_READ_ERROR_FROM_PIPE

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -550,13 +550,14 @@ class ClientTest < TrilogyTest
     assert_equal "Attempted to use closed connection", err.message
   end
 
-  def test_database_error
+  def test_query_error
     client = new_tcp_client
 
-    err = assert_raises Trilogy::ProtocolError do
+    err = assert_raises Trilogy::QueryError do
       client.query("not legit sqle")
     end
 
+    assert_equal 1064, err.error_code
     assert_includes err.message, "You have an error in your SQL syntax"
 
     # test that the connection is not closed due to 'routine' errors

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -369,7 +369,7 @@ class ClientTest < TrilogyTest
   def test_read_timeout
     client = new_tcp_client(read_timeout: 0.1)
 
-    assert_raises Errno::ETIMEDOUT do
+    assert_raises Trilogy::TimeoutError do
       client.query("SELECT SLEEP(1)")
     end
   ensure
@@ -381,7 +381,7 @@ class ClientTest < TrilogyTest
     assert client.query("SELECT SLEEP(0.2)");
     client.read_timeout = 0.1
     assert_equal 0.1, client.read_timeout
-    assert_raises Errno::ETIMEDOUT do
+    assert_raises Trilogy::TimeoutError do
       client.query("SELECT SLEEP(1)")
     end
   ensure
@@ -429,7 +429,7 @@ class ClientTest < TrilogyTest
     serv = TCPServer.new(0)
     port = serv.addr[1]
 
-    assert_raises Errno::ETIMEDOUT do
+    assert_raises Trilogy::TimeoutError do
       new_tcp_client(host: "127.0.0.1", port: port, connect_timeout: 0.1)
     end
   ensure

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -532,7 +532,7 @@ class ClientTest < TrilogyTest
   end
 
   def test_connection_error
-    err = assert_raises Trilogy::BaseConnectionError do
+    err = assert_raises Trilogy::ConnectionError do
       new_tcp_client(username: "foo")
     end
 
@@ -732,10 +732,10 @@ class ClientTest < TrilogyTest
   end
 
   def test_connection_invalid_dns
-    ex = assert_raises Trilogy::Error do
+    ex = assert_raises Trilogy::ConnectionError do
       new_tcp_client(host: "mysql.invalid", port: 3306)
     end
-    assert_equal "trilogy_connect - unable to connect to mysql.invalid:3306: TRILOGY_DNS_ERR", ex.message
+    assert_equal "trilogy_connect - unable to connect to mysql.invalid:3306: TRILOGY_DNS_ERROR", ex.message
   end
 
   def test_memsize

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -37,10 +37,10 @@ class ClientTest < TrilogyTest
   end
 
   def test_trilogy_connect_tcp_to_wrong_port
-    e = assert_raises Errno::ECONNREFUSED do
+    e = assert_raises Trilogy::ConnectionError do
       new_tcp_client port: 13307
     end
-    assert_equal "Connection refused - trilogy_connect - unable to connect to #{DEFAULT_HOST}:13307", e.message
+    assert_equal "trilogy_connect - unable to connect to #{DEFAULT_HOST}:13307", e.message
   end
 
   def test_trilogy_connect_unix_socket
@@ -123,11 +123,10 @@ class ClientTest < TrilogyTest
     create_test_table(client)
 
     refute_predicate client, :more_results_exist?
-    result = client.query("INSERT INTO trilogy_test (int_test) VALUES ('4')")
+    client.query("INSERT INTO trilogy_test (int_test) VALUES ('4')")
     refute_predicate client, :more_results_exist?
 
-
-    result = client.query("INSERT INTO trilogy_test (int_test) VALUES ('4'); INSERT INTO trilogy_test (int_test) VALUES ('1')")
+    client.query("INSERT INTO trilogy_test (int_test) VALUES ('4'); INSERT INTO trilogy_test (int_test) VALUES ('1')")
     assert_predicate client, :more_results_exist?
   end
 
@@ -738,7 +737,7 @@ class ClientTest < TrilogyTest
     _, fake_port = fake_server.addr
     fake_server.close
 
-    assert_raises Errno::ECONNREFUSED do
+    assert_raises Trilogy::ConnectionError do
       new_tcp_client(host: "127.0.0.1", port: fake_port)
     end
   end

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -531,6 +531,7 @@ class ClientTest < TrilogyTest
   end
 
   def test_connection_error
+    skip("Test fails intermittently with TRILOGY_PROTOCOL_VIOLATION. See https://github.com/github/trilogy/pull/42")
     err = assert_raises Trilogy::ConnectionError do
       new_tcp_client(username: "foo")
     end

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -73,7 +73,7 @@ class ClientTest < TrilogyTest
     client = new_tcp_client
     assert client.ping
     client.close
-    assert_raises IOError do
+    assert_raises Trilogy::ConnectionClosed do
       client.ping
     end
   ensure
@@ -91,7 +91,7 @@ class ClientTest < TrilogyTest
     client = new_tcp_client
     assert client.change_db "test"
     client.close
-    assert_raises IOError do
+    assert_raises Trilogy::ConnectionClosed do
       refute client.change_db "test"
     end
   ensure
@@ -216,7 +216,7 @@ class ClientTest < TrilogyTest
     client = new_tcp_client
     assert client.query "SELECT 1"
     client.close
-    assert_raises IOError do
+    assert_raises Trilogy::ConnectionClosed do
       refute client.query "SELECT 1"
     end
   ensure
@@ -393,11 +393,11 @@ class ClientTest < TrilogyTest
     client.close
     ensure_closed client
 
-    assert_raises IOError do
+    assert_raises Trilogy::ConnectionClosed do
       client.read_timeout
     end
 
-    assert_raises IOError do
+    assert_raises Trilogy::ConnectionClosed do
       client.read_timeout = 42
     end
   end
@@ -416,11 +416,11 @@ class ClientTest < TrilogyTest
     client.close
     ensure_closed client
 
-    assert_raises IOError do
+    assert_raises Trilogy::ConnectionClosed do
       client.write_timeout
     end
 
-    assert_raises IOError do
+    assert_raises Trilogy::ConnectionClosed do
       client.write_timeout = 42
     end
   end
@@ -537,6 +537,18 @@ class ClientTest < TrilogyTest
     end
 
     assert_includes err.message, "Access denied for user 'foo'"
+  end
+
+  def test_connection_closed_error
+    client = new_tcp_client
+
+    client.close
+
+    err = assert_raises Trilogy::ConnectionClosed do
+      client.query("SELECT 1");
+    end
+
+    assert_equal "Attempted to use closed connection", err.message
   end
 
   def test_database_error


### PR DESCRIPTION
Follow up to: https://github.com/github/trilogy/pull/15

Converts a few more Trilogy errors:
- `TRILOGY_DNS_ERROR` is generally returned when we attempt to connect to a db with an unknown hostname, which we should treat as a connection error and handle properly [in the adapter](https://github.com/github/activerecord-trilogy-adapter/blob/main/lib/active_record/connection_adapters/trilogy_adapter.rb#L98-L99).
- `Trilogy::ConnectionClosed` was introduced in the last PR to handle `IOError`, but I forgot to actually raise the Trilogy error in the C ext, so that's been updated
- Handles known syscall errors: `ECONNREFUSED` and `ECONNRESET`, which should both be handled as connection errors. These are the ones I've been encountering frequently; we can expand on the error conversions as we see more pop up. I'm not sure how many of the 107 syscall errors we actually expect to see.

I plan to update https://github.com/github/activerecord-trilogy-adapter/pull/24 to handle these changes.