### PR TITLE
Avoid protocol error on empty password auth switch

### DIFF
--- a/src/client.c
+++ b/src/client.c
@@ -259,10 +259,12 @@ static int read_auth_switch_packet(trilogy_conn_t *conn, trilogy_handshake_t *ha
         return rc;
     }
 
-    if (strcmp("mysql_native_password", auth_switch_packet.auth_plugin) &&
-        strcmp("caching_sha2_password", auth_switch_packet.auth_plugin)) {
-        // Only support native password & caching sha2 password here.
-        return TRILOGY_PROTOCOL_VIOLATION;
+    if (conn->socket->opts.password_len > 0) {
+        if (strcmp("mysql_native_password", auth_switch_packet.auth_plugin) &&
+            strcmp("caching_sha2_password", auth_switch_packet.auth_plugin)) {
+            // Only support native password & caching sha2 password here.
+            return TRILOGY_PROTOCOL_VIOLATION;
+        }
     }
 
     memcpy(handshake->auth_plugin, auth_switch_packet.auth_plugin, sizeof(auth_switch_packet.auth_plugin));


### PR DESCRIPTION
Prior to this commit `test_connection_error`, which creates a connection with a username that doesn't exist and an empty password, was flaky on mysql 8. Sometimes it passed with the expected BaseConnectionError, but often it failed with a `TRILOGY_PROTOCOL_VIOLATION`.

The source of the `TRILOGY_PROTOCOL_VIOLATION` was `read_auth_switch_packet`, which only handles `mysql_native_password` and `caching_sha2_password`, whereas in the case of this failure the attempted auth switch was to `sha256_password`.

I'm not entirely sure why we get an auth switch packet sometimes and an "access denied" error packet other times (I'm guessing it has something to do with mysql 8 changing the default auth plugin to the caching plugin, but that's really just a guess). But in the case of an empty password it seems like we can handle the switch just fine. We've done a similar password_length check in https://github.com/github/trilogy/pull/21.

With this commit test_connection_error passes consistently.