### PR TITLE
Have test_connection_error test user account with wrong password

### DIFF
--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -531,12 +531,11 @@ class ClientTest < TrilogyTest
   end
 
   def test_connection_error
-    skip("Test fails intermittently with TRILOGY_PROTOCOL_VIOLATION. See https://github.com/github/trilogy/pull/42")
     err = assert_raises Trilogy::ConnectionError do
-      new_tcp_client(username: "foo")
+      new_tcp_client(username: "native", password: "incorrect")
     end
 
-    assert_includes err.message, "Access denied for user 'foo'"
+    assert_includes err.message, "Access denied for user 'native'"
   end
 
   def test_connection_closed_error


### PR DESCRIPTION
This test was being skipped for reasons described in https://github.com/github/trilogy/issues/43.
Instead of testing for a connection error by using a nonexistent user, we can use an existing user with the wrong password. This appears to avoid the authentication plugin flakiness, while still executing the code path we care about related to an "Access denied" connection error.

Is it still worth having a skipped test with an invalid username so that the issue remains on our radar? 