### PR TITLE
Expose `#connection_options` on the Ruby binding.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ## Unreleased
 
 ### Added
-  - Implement multi-statement support on the Ruby binding. 
+  - Implement multi-statement support on the Ruby binding.
+  - Add `#connection_options` method to Ruby binding.
 
 ## 2.2.0
 

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -22,7 +22,8 @@ static ID id_socket, id_host, id_port, id_username, id_password, id_found_rows, 
     id_write_timeout, id_keepalive_enabled, id_keepalive_idle, id_keepalive_interval, id_keepalive_count,
     id_ivar_affected_rows, id_ivar_fields, id_ivar_last_insert_id, id_ivar_rows, id_ivar_query_time, id_password,
     id_database, id_ssl_ca, id_ssl_capath, id_ssl_cert, id_ssl_cipher, id_ssl_crl, id_ssl_crlpath, id_ssl_key,
-    id_ssl_mode, id_tls_ciphersuites, id_tls_min_version, id_tls_max_version, id_multi_statement, id_from_code;
+    id_ssl_mode, id_tls_ciphersuites, id_tls_min_version, id_tls_max_version, id_multi_statement, id_from_code,
+    id_connection_options;
 
 struct trilogy_ctx {
     trilogy_conn_t conn;
@@ -365,6 +366,7 @@ static VALUE rb_trilogy_initialize(VALUE self, VALUE opts)
     VALUE val;
 
     Check_Type(opts, T_HASH);
+    rb_ivar_set(self, id_connection_options, opts);
 
     if ((val = rb_hash_lookup(opts, ID2SYM(id_ssl_mode))) != Qnil) {
         Check_Type(val, T_FIXNUM);
@@ -1062,6 +1064,7 @@ void Init_cext()
     id_ivar_last_insert_id = rb_intern("@last_insert_id");
     id_ivar_rows = rb_intern("@rows");
     id_ivar_query_time = rb_intern("@query_time");
+    id_connection_options = rb_intern("@connection_options");
 
     rb_trilogy_cast_init();
 

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -84,6 +84,10 @@ class Trilogy
     include ConnectionError
   end
 
+  def connection_options
+    @connection_options.dup.freeze
+  end
+
   def in_transaction?
     (server_status & SERVER_STATUS_IN_TRANS) != 0
   end

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -62,6 +62,21 @@ class ClientTest < TrilogyTest
     end
   end
 
+  def test_trilogy_connection_options
+    client = new_tcp_client
+
+    expected_connection_options = {
+      host: DEFAULT_HOST,
+      port: DEFAULT_PORT,
+      username: DEFAULT_USER,
+      password: DEFAULT_PASS,
+      ssl: true,
+      ssl_mode: 4,
+      tls_min_version: 3,
+    }
+    assert_equal expected_connection_options, client.connection_options
+  end
+
   def test_trilogy_ping
     client = new_tcp_client
     assert client.ping


### PR DESCRIPTION
This PR exposes a `#connection_options` method on the Ruby binding, allowing users to query the client for the options passed in at connect time. This is meant to be similar to [Mysql2's `#query_options`](https://www.rubydoc.info/gems/mysql2/Mysql2/Client#query_options-instance_method).

We're currently using `Mysql2::Client#query_options`  in a couple of places in our Rails apps at Shopify, and there's no equivalent in Trilogy -- we could go through the connection pool and grab the `db_config` instead, but it's nice to be able to access connection options on the client IMHO. It also facilitates other use cases, like being able to configure span name for MySQL instrumentation with OpenTelemetry (just as is being done for [Mysql2](https://github.com/open-telemetry/opentelemetry-ruby-contrib/blob/main/instrumentation/mysql2/lib/opentelemetry/instrumentation/mysql2/patches/client.rb#L117-L120)).

As an aside: I've noticed that there are a couple of places (e.g. benchmark [script](https://github.com/github/trilogy/blob/main/contrib/ruby/script/benchmark#L86), [docs](https://github.com/github/trilogy/tree/main/contrib/ruby#mysql2-gem-compatibility)) where we reference a non-existent `#query_options` method. I'm wondering if this was removed from the API at some point? Is there any value to bringing that back in addition to `#connection_options`? If not, I can remove those references to avoid confusion 😄 