### PR TITLE
Preserve DatabaseError constant

### DIFF
--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -51,7 +51,15 @@ class Trilogy
     end
   end
 
+  # DatabaseError was replaced by ProtocolError, but we'll keep it around as an
+  # ancestor of ProtocolError for compatibility reasons (e.g. so `rescue DatabaseError`
+  # still works. We can remove this class in the next major release.
+  module DatabaseError
+  end
+
   class ProtocolError < BaseError
+    include DatabaseError
+
     ERROR_CODES = {
       1205 => TimeoutError, # ER_LOCK_WAIT_TIMEOUT
       1044 => BaseConnectionError, # ER_DBACCESS_DENIED_ERROR

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -702,6 +702,7 @@ class ClientTest < TrilogyTest
     end
 
     assert_equal 1040, ex.error_code
+    assert ex.is_a?(Trilogy::DatabaseError)
   ensure
     accept_thread.join
     fake_server.close


### PR DESCRIPTION
https://github.com/github/trilogy/pull/15 changed the error class for TRILOGY_ERR from `DatabaseError` to `ProtocolError`. This commit reintroduces `DatabaseError` as an ancestor of `ProtocolError` for compatibility reasons, so that rescuing `DatabaseError` still works (mostly) as before.

Note that even with this change there are a number of error codes (see `ProtocolError::ERROR_CODES`) that are no longer `DatabaseError`s, since we have explicitly recategorized them as `BaseConnectionError`, `TimeoutError`, or `QueryError`.