### PR TITLE
Replace references to query_options

### DIFF
--- a/contrib/ruby/Gemfile.lock
+++ b/contrib/ruby/Gemfile.lock
@@ -8,7 +8,7 @@ GEM
   specs:
     benchmark-ips (2.7.2)
     minitest (5.11.3)
-    mysql2 (0.5.2)
+    mysql2 (0.5.5)
     rake (13.0.1)
     rake-compiler (1.0.7)
       rake

--- a/contrib/ruby/README.md
+++ b/contrib/ruby/README.md
@@ -65,7 +65,7 @@ The official Ruby bindings are inside of the canonical trilogy repository itself
 The trilogy API was heavily inspired by the mysql2 gem but has a few notable
 differences:
 
-* The `query_options` hash doesn't inherit from the connection options hash.
+* The `query_flags` don't inherit from the connection options hash.
   This means that options like turning on/of casting will need to be set before
   a query and not passed in at connect time.
 * For performance reasons there is no `application_timezone` query option. If

--- a/contrib/ruby/script/benchmark
+++ b/contrib/ruby/script/benchmark
@@ -83,7 +83,7 @@ Benchmark.ips do |x|
   end
 
   x.report "trilogy query (no-casting)" do
-    trilogy_client.query_options[:cast] = false
+    trilogy_client.query_flags &= ~Trilogy::QUERY_FLAGS_CAST
     result = trilogy_client.query QUERY
     result.to_a
   end


### PR DESCRIPTION
query_options were replaced with the query_flags bitmap.

The benchmark script was broken before this change. While fixing it I also bumped the locked mysql2 version since it was easier to install on MacOS.