### PR TITLE
Raise system error subclasses

### DIFF
--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -51,6 +51,14 @@ class Trilogy
     end
   end
 
+  class ConnectionRefusedError < Errno::ECONNREFUSED
+    include ConnectionError
+  end
+
+  class ConnectionResetError < Errno::ECONNRESET
+    include ConnectionError
+  end
+
   # DatabaseError was replaced by ProtocolError, but we'll keep it around as an
   # ancestor of ProtocolError for compatibility reasons (e.g. so `rescue DatabaseError`
   # still works. We can remove this class in the next major release.

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -40,7 +40,7 @@ class ClientTest < TrilogyTest
     e = assert_raises Trilogy::ConnectionError do
       new_tcp_client port: 13307
     end
-    assert_equal "trilogy_connect - unable to connect to #{DEFAULT_HOST}:13307", e.message
+    assert_equal "Connection refused - trilogy_connect - unable to connect to #{DEFAULT_HOST}:13307", e.message
   end
 
   def test_trilogy_connect_unix_socket


### PR DESCRIPTION
https://github.com/github/trilogy/pull/41 added a translation of `ECONNREFUSED` and `ECONNRESET` to `Trilogy::BaseConnectionError`.

We've got a few places at GitHub where we explicitly rescue these errors (or `SystemCallError`). Although it is possible to rework those rescues to check for particular error messages (like we did in
https://github.com/github/activerecord-trilogy-adapter/commit/03c16105c8ea5da4c90f837b607e97b1b2dcd6d0), it'd be a bit easier if we could maintain compatibility. I also worry that checking for specific error messages could be a bit brittle.

This commit introduces two new Trilogy errors, which inherit from the corresponding `Errno` errors. We've already done something like this for `Errno::ETIMEDOUT`.

This keeps Trilogy compatible with GitHub's existing rescues, while still raising something that is a `Trilogy::Error` and a `Trilogy::ConnectionError` (although NOT a
`Trilogy::BaseConnectionError` anymore).

A downside to this approach is that we might end up with a lot of Trilogy-specific `Errno` subclasses. If that gets annoying perhaps we could revisit when it comes time for a major release. Another approach might be a single `Trilogy::SystemCallError` that inherits from `SystemCallError` and then keeps a reference to the underlying `Errno` error.

cc @adrianna-chang-shopify 