### PR TITLE
Ensure Trilogy::Result objects have a consistent shape

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -685,6 +685,9 @@ static VALUE read_query_response(VALUE vargs)
         rb_ivar_set(result, id_ivar_affected_rows, ULL2NUM(ctx->conn.affected_rows));
 
         return result;
+    } else {
+        rb_ivar_set(result, id_ivar_last_insert_id, Qnil);
+        rb_ivar_set(result, id_ivar_affected_rows, Qnil);
     }
 
     struct column_info *column_info = ALLOC_N(struct column_info, column_count);
@@ -1073,9 +1076,6 @@ void Init_cext()
 
     Trilogy_CastError = rb_const_get(Trilogy, rb_intern("CastError"));
     rb_global_variable(&Trilogy_CastError);
-
-    rb_define_attr(Trilogy_Result, "affected_rows", 1, 0);
-    rb_define_attr(Trilogy_Result, "last_insert_id", 1, 0);
 
     id_socket = rb_intern("socket");
     id_host = rb_intern("host");

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -139,7 +139,7 @@ class Trilogy
   end
 
   class Result
-    attr_reader :fields, :rows, :query_time
+    attr_reader :fields, :rows, :query_time, :affected_rows, :last_insert_id
 
     def count
       rows.count


### PR DESCRIPTION
Only really useful on 3.2+.

There is also the question of wether it may be speadier to define a constructor and call it from C to assign these ivar because `rb_ivar_set` is slower than assigning instance variables from Ruby nowadays (but that's for a potential followup).