### PR TITLE
Hide all symbols

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -51,7 +51,7 @@ static size_t trilogy_memsize(const void *ptr) {
     return memsize;
 }
 
-const rb_data_type_t trilogy_data_type = {
+static const rb_data_type_t trilogy_data_type = {
     .wrap_struct_name = "trilogy",
     .function = {
         .dmark = NULL,
@@ -959,7 +959,7 @@ static VALUE rb_trilogy_server_status(VALUE self) { return LONG2FIX(get_open_ctx
 
 static VALUE rb_trilogy_server_version(VALUE self) { return rb_str_new_cstr(get_open_ctx(self)->server_version); }
 
-void Init_cext()
+RUBY_FUNC_EXPORTED void Init_cext()
 {
     VALUE Trilogy = rb_const_get(rb_cObject, rb_intern("Trilogy"));
     rb_define_alloc_func(Trilogy, allocate_trilogy);

--- a/contrib/ruby/ext/trilogy-ruby/extconf.rb
+++ b/contrib/ruby/ext/trilogy-ruby/extconf.rb
@@ -6,7 +6,7 @@ File.binwrite("trilogy.c",
   Dir["#{__dir__}/src/**/*.c"].map { |src| File.binread(src) }.join)
 
 $objs = %w[trilogy.o cast.o cext.o]
-$CFLAGS << " -I #{__dir__}/inc -std=gnu99"
+$CFLAGS << " -I #{__dir__}/inc -std=gnu99 -fvisibility=hidden"
 
 dir_config("openssl")
 


### PR DESCRIPTION
Otherwise, while unlikely, if another gem define similar symbols it can lead to cratastorpic issues.

See https://github.com/msgpack/msgpack-ruby/pull/317 for an example.