### PR TITLE
Trilogy errors all inherit from base Trilogy::Error class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 
 ## Unreleased
 
+### Changed
+- (Breaking change) Trilogy errors all inherit from base Trilogy::Error class. #58
+
 ## 2.3.0
 
 ### Added

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -15,7 +15,7 @@
 #define TRILOGY_RB_TIMEOUT 1
 
 VALUE Trilogy_CastError;
-static VALUE Trilogy_BaseConnectionError, Trilogy_ProtocolError, Trilogy_SSLError, Trilogy_QueryError,
+static VALUE Trilogy_ConnectionError, Trilogy_ProtocolError, Trilogy_SSLError, Trilogy_QueryError,
     Trilogy_ConnectionClosedError, Trilogy_ConnectionRefusedError, Trilogy_ConnectionResetError,
     Trilogy_TimeoutError, Trilogy_Result;
 
@@ -126,7 +126,7 @@ static void handle_trilogy_error(struct trilogy_ctx *ctx, int rc, const char *ms
     }
 
     case TRILOGY_DNS_ERR: {
-        rb_raise(Trilogy_BaseConnectionError, "%" PRIsVALUE ": TRILOGY_DNS_ERROR", rbmsg);
+        rb_raise(Trilogy_ConnectionError, "%" PRIsVALUE ": TRILOGY_DNS_ERROR", rbmsg);
     }
 
     default:
@@ -1021,8 +1021,8 @@ void Init_cext()
     Trilogy_ConnectionResetError = rb_const_get(Trilogy, rb_intern("ConnectionResetError"));
     rb_global_variable(&Trilogy_ConnectionResetError);
 
-    Trilogy_BaseConnectionError = rb_const_get(Trilogy, rb_intern("BaseConnectionError"));
-    rb_global_variable(&Trilogy_BaseConnectionError);
+    Trilogy_ConnectionError = rb_const_get(Trilogy, rb_intern("ConnectionError"));
+    rb_global_variable(&Trilogy_ConnectionError);
 
     Trilogy_ConnectionClosedError = rb_const_get(Trilogy, rb_intern("ConnectionClosed"));
     rb_global_variable(&Trilogy_ConnectionClosedError);

--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -1,20 +1,9 @@
 require "trilogy/version"
 
 class Trilogy
-  # Trilogy::Error is the base error type. All errors raised by Trilogy
-  # should be descendants of Trilogy::Error
-  module Error
-  end
-
-  # Trilogy::ConnectionError is the base error type for all potentially transient
-  # network errors.
-  module ConnectionError
-    include Error
-  end
-
-  class BaseError < StandardError
-    include Error
-
+  # Base error type for all Trilogy errors. All errors raised by Trilogy should
+  # be descendants of this class.
+  class Error < StandardError
     attr_reader :error_code
 
     def initialize(error_message = nil, error_code = nil)
@@ -24,66 +13,52 @@ class Trilogy
     end
   end
 
-  class BaseConnectionError < BaseError
-    include ConnectionError
+  # Base error type for all potentially transient network errors.
+  class ConnectionError < Error
   end
 
-  # Trilogy::ClientError is the base error type for invalid queries or parameters
-  # that shouldn't be retried.
-  class ClientError < BaseError
-    include Error
+  # Base error type for invalid queries or parameters. ClientErrors shouldn't be retried.
+  class ClientError < Error
   end
 
+  # Raised when client makes invalid query.
   class QueryError < ClientError
   end
 
+  # Raised when casting a value fails during a query.
   class CastError < ClientError
   end
 
-  class TimeoutError < Errno::ETIMEDOUT
-    include ConnectionError
-
-    attr_reader :error_code
-
-    def initialize(error_message = nil, error_code = nil)
-      super
-      @error_code = error_code
-    end
+  # Raised when client times out while connecting to the db or performing a query.
+  class TimeoutError < ConnectionError
   end
 
-  class ConnectionRefusedError < Errno::ECONNREFUSED
-    include ConnectionError
+  # Raised when Trilogy connection is refused.
+  class ConnectionRefusedError < ConnectionError
   end
 
-  class ConnectionResetError < Errno::ECONNRESET
-    include ConnectionError
+  # Raised when Trilogy connection is reset.
+  class ConnectionResetError < ConnectionError
   end
 
-  # DatabaseError was replaced by ProtocolError, but we'll keep it around as an
-  # ancestor of ProtocolError for compatibility reasons (e.g. so `rescue DatabaseError`
-  # still works. We can remove this class in the next major release.
-  module DatabaseError
-  end
-
-  class ProtocolError < BaseError
-    include DatabaseError
-
+  # Raised when server encounters error.
+  class ProtocolError < Error
     ERROR_CODES = {
       1205 => TimeoutError, # ER_LOCK_WAIT_TIMEOUT
-      1044 => BaseConnectionError, # ER_DBACCESS_DENIED_ERROR
-      1045 => BaseConnectionError, # ER_ACCESS_DENIED_ERROR
+      1044 => ConnectionError, # ER_DBACCESS_DENIED_ERROR
+      1045 => ConnectionError, # ER_ACCESS_DENIED_ERROR
       1064 => QueryError, # ER_PARSE_ERROR
-      1152 => BaseConnectionError, # ER_ABORTING_CONNECTION
-      1153 => BaseConnectionError, # ER_NET_PACKET_TOO_LARGE
-      1154 => BaseConnectionError, # ER_NET_READ_ERROR_FROM_PIPE
-      1155 => BaseConnectionError, # ER_NET_FCNTL_ERROR
-      1156 => BaseConnectionError, # ER_NET_PACKETS_OUT_OF_ORDER
-      1157 => BaseConnectionError, # ER_NET_UNCOMPRESS_ERROR
-      1158 => BaseConnectionError, # ER_NET_READ_ERROR
-      1159 => BaseConnectionError, # ER_NET_READ_INTERRUPTED
-      1160 => BaseConnectionError, # ER_NET_ERROR_ON_WRITE
-      1161 => BaseConnectionError, # ER_NET_WRITE_INTERRUPTED
-      1927 => BaseConnectionError, # ER_CONNECTION_KILLED
+      1152 => ConnectionError, # ER_ABORTING_CONNECTION
+      1153 => ConnectionError, # ER_NET_PACKET_TOO_LARGE
+      1154 => ConnectionError, # ER_NET_READ_ERROR_FROM_PIPE
+      1155 => ConnectionError, # ER_NET_FCNTL_ERROR
+      1156 => ConnectionError, # ER_NET_PACKETS_OUT_OF_ORDER
+      1157 => ConnectionError, # ER_NET_UNCOMPRESS_ERROR
+      1158 => ConnectionError, # ER_NET_READ_ERROR
+      1159 => ConnectionError, # ER_NET_READ_INTERRUPTED
+      1160 => ConnectionError, # ER_NET_ERROR_ON_WRITE
+      1161 => ConnectionError, # ER_NET_WRITE_INTERRUPTED
+      1927 => ConnectionError, # ER_CONNECTION_KILLED
     }
     class << self
       def from_code(message, code)
@@ -92,12 +67,12 @@ class Trilogy
     end
   end
 
-  class SSLError < BaseError
-    include ConnectionError
+  # Raised when call to OpenSSL fails.
+  class SSLError < ConnectionError
   end
 
-  class ConnectionClosed < IOError
-    include ConnectionError
+  # Raised when Trilogy connection is closed.
+  class ConnectionClosed < ConnectionError
   end
 
   def connection_options

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -40,7 +40,7 @@ class ClientTest < TrilogyTest
     e = assert_raises Trilogy::ConnectionError do
       new_tcp_client port: 13307
     end
-    assert_equal "Connection refused - trilogy_connect - unable to connect to #{DEFAULT_HOST}:13307", e.message
+    assert_equal "trilogy_connect - unable to connect to #{DEFAULT_HOST}:13307", e.message
   end
 
   def test_trilogy_connect_unix_socket
@@ -702,7 +702,6 @@ class ClientTest < TrilogyTest
     end
 
     assert_equal 1040, ex.error_code
-    assert ex.is_a?(Trilogy::DatabaseError)
   ensure
     accept_thread.join
     fake_server.close


### PR DESCRIPTION
This PR makes breaking changes to the error classes. All Trilogy errors are now descendants of the base error class, `Trilogy::Error`, and no longer inherit from syscall errors. This will need to go out as part of a major release.

More context on original introduction of these error classes: https://github.com/github/trilogy/pull/15

I also attempted to add some docs for the various error classes. Feedback welcome! 🙇‍♀️ 

cc @byroot 