### PR TITLE
Ensure syscall error subclasses have an error_code attribute

### DIFF
--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -4,6 +4,7 @@ class Trilogy
   # Trilogy::Error is the base error type. All errors raised by Trilogy
   # should be descendants of Trilogy::Error
   module Error
+    attr_reader :error_code
   end
 
   # Trilogy::ConnectionError is the base error type for all potentially transient
@@ -14,8 +15,6 @@ class Trilogy
 
   class BaseError < StandardError
     include Error
-
-    attr_reader :error_code
 
     def initialize(error_message = nil, error_code = nil)
       message = error_code ? "#{error_code}: #{error_message}" : error_message
@@ -43,8 +42,6 @@ class Trilogy
   class TimeoutError < Errno::ETIMEDOUT
     include ConnectionError
 
-    attr_reader :error_code
-
     def initialize(error_message = nil, error_code = nil)
       super
       @error_code = error_code
@@ -53,10 +50,20 @@ class Trilogy
 
   class ConnectionRefusedError < Errno::ECONNREFUSED
     include ConnectionError
+
+    def initialize(error_message = nil, error_code = nil)
+      super
+      @error_code = error_code
+    end
   end
 
   class ConnectionResetError < Errno::ECONNRESET
     include ConnectionError
+
+    def initialize(error_message = nil, error_code = nil)
+      super
+      @error_code = error_code
+    end
   end
 
   # DatabaseError was replaced by ProtocolError, but we'll keep it around as an


### PR DESCRIPTION
https://github.com/github/trilogy/pull/53 ensured backwards compatibility for error classes by maintaining `ConnectionRefusedError` and `ConnectionResetError` as subclasses of their original syscall errors (`ECONNREFUSED` and `ECONNRESET` respectively). However, this meant no longer init'ing these errors with the appropriate `error_code`, which happens in `BaseError` right now:
https://github.com/github/trilogy/blob/80c1a55207ed87adb93c4798f0d11ca195a827a1/contrib/ruby/lib/trilogy.rb#L18-L24

This PR ensures these two errors are initialized with the `error_code` attribute set. Without it, we'll see [failures](https://github.com/github/activerecord-trilogy-adapter/actions/runs/4429828369/jobs/7770773157#step:7:39) when the Trilogy adapter calls [`#error_code`](https://github.com/github/activerecord-trilogy-adapter/blame/ccd2a41ec144d13ab252fef850bdbede20811703/lib/active_record/connection_adapters/trilogy_adapter.rb#L98).

There's some duplication between the various error classes that still inherit from syscall errors (although I did move the attr_reader up to the `Trilogy::Error` module), but I'd like to get all of this cleaned up in https://github.com/github/trilogy/pull/58 anyways, so it should be fairly temporary.

cc @composerinteralia if this looks okay to you I'll merge! 😄 
