### PR TITLE
Add a query flag to toggle the type of casting done by SUM

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cast.c
+++ b/contrib/ruby/ext/trilogy-ruby/cast.c
@@ -145,7 +145,7 @@ rb_trilogy_cast_value(const trilogy_value_t *value, const struct column_info *co
             // TODO - optimize so we don't have to allocate a ruby string for
             // decimal columns
             VALUE str = rb_str_new(value->data, value->data_len);
-            if (column->decimals == 0) {
+            if (column->decimals == 0 && !options->cast_sum) {
                 return rb_funcall(rb_mKernel, id_Integer, 1, str);
             } else {
                 return rb_funcall(rb_mKernel, id_BigDecimal, 1, str);

--- a/contrib/ruby/ext/trilogy-ruby/cast.c
+++ b/contrib/ruby/ext/trilogy-ruby/cast.c
@@ -145,7 +145,7 @@ rb_trilogy_cast_value(const trilogy_value_t *value, const struct column_info *co
             // TODO - optimize so we don't have to allocate a ruby string for
             // decimal columns
             VALUE str = rb_str_new(value->data, value->data_len);
-            if (column->decimals == 0 && !options->cast_sum) {
+            if (column->decimals == 0 && !options->cast_decimals_to_bigdecimals) {
                 return rb_funcall(rb_mKernel, id_Integer, 1, str);
             } else {
                 return rb_funcall(rb_mKernel, id_BigDecimal, 1, str);

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -594,6 +594,7 @@ static void load_query_options(unsigned int query_flags, struct rb_trilogy_cast_
 {
     cast_options->cast = (query_flags & TRILOGY_FLAGS_CAST) != 0;
     cast_options->cast_booleans = (query_flags & TRILOGY_FLAGS_CAST_BOOLEANS) != 0;
+    cast_options->cast_sum = (query_flags & TRILOGY_FLAGS_CAST_SUM) != 0;
     cast_options->database_local_time = (query_flags & TRILOGY_FLAGS_LOCAL_TIMEZONE) != 0;
     cast_options->flatten_rows = (query_flags & TRILOGY_FLAGS_FLATTEN_ROWS) != 0;
 }
@@ -1038,6 +1039,7 @@ void Init_cext()
     rb_define_const(Trilogy, "QUERY_FLAGS_NONE", INT2NUM(0));
     rb_define_const(Trilogy, "QUERY_FLAGS_CAST", INT2NUM(TRILOGY_FLAGS_CAST));
     rb_define_const(Trilogy, "QUERY_FLAGS_CAST_BOOLEANS", INT2NUM(TRILOGY_FLAGS_CAST_BOOLEANS));
+    rb_define_const(Trilogy, "QUERY_FLAGS_CAST_SUM", INT2NUM(TRILOGY_FLAGS_CAST_SUM));
     rb_define_const(Trilogy, "QUERY_FLAGS_LOCAL_TIMEZONE", INT2NUM(TRILOGY_FLAGS_LOCAL_TIMEZONE));
     rb_define_const(Trilogy, "QUERY_FLAGS_FLATTEN_ROWS", INT2NUM(TRILOGY_FLAGS_FLATTEN_ROWS));
     rb_define_const(Trilogy, "QUERY_FLAGS_DEFAULT", INT2NUM(TRILOGY_FLAGS_DEFAULT));

--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -594,7 +594,7 @@ static void load_query_options(unsigned int query_flags, struct rb_trilogy_cast_
 {
     cast_options->cast = (query_flags & TRILOGY_FLAGS_CAST) != 0;
     cast_options->cast_booleans = (query_flags & TRILOGY_FLAGS_CAST_BOOLEANS) != 0;
-    cast_options->cast_sum = (query_flags & TRILOGY_FLAGS_CAST_SUM) != 0;
+    cast_options->cast_decimals_to_bigdecimals = (query_flags & TRILOGY_FLAGS_CAST_ALL_DECIMALS_TO_BIGDECIMALS) != 0;
     cast_options->database_local_time = (query_flags & TRILOGY_FLAGS_LOCAL_TIMEZONE) != 0;
     cast_options->flatten_rows = (query_flags & TRILOGY_FLAGS_FLATTEN_ROWS) != 0;
 }
@@ -1039,7 +1039,7 @@ void Init_cext()
     rb_define_const(Trilogy, "QUERY_FLAGS_NONE", INT2NUM(0));
     rb_define_const(Trilogy, "QUERY_FLAGS_CAST", INT2NUM(TRILOGY_FLAGS_CAST));
     rb_define_const(Trilogy, "QUERY_FLAGS_CAST_BOOLEANS", INT2NUM(TRILOGY_FLAGS_CAST_BOOLEANS));
-    rb_define_const(Trilogy, "QUERY_FLAGS_CAST_SUM", INT2NUM(TRILOGY_FLAGS_CAST_SUM));
+    rb_define_const(Trilogy, "QUERY_FLAGS_CAST_ALL_DECIMALS_TO_BIGDECIMALS", INT2NUM(TRILOGY_FLAGS_CAST_ALL_DECIMALS_TO_BIGDECIMALS));
     rb_define_const(Trilogy, "QUERY_FLAGS_LOCAL_TIMEZONE", INT2NUM(TRILOGY_FLAGS_LOCAL_TIMEZONE));
     rb_define_const(Trilogy, "QUERY_FLAGS_FLATTEN_ROWS", INT2NUM(TRILOGY_FLAGS_FLATTEN_ROWS));
     rb_define_const(Trilogy, "QUERY_FLAGS_DEFAULT", INT2NUM(TRILOGY_FLAGS_DEFAULT));

--- a/contrib/ruby/ext/trilogy-ruby/trilogy-ruby.h
+++ b/contrib/ruby/ext/trilogy-ruby/trilogy-ruby.h
@@ -9,6 +9,7 @@
 #define TRILOGY_FLAGS_CAST_BOOLEANS 2
 #define TRILOGY_FLAGS_LOCAL_TIMEZONE 4
 #define TRILOGY_FLAGS_FLATTEN_ROWS 8
+#define TRILOGY_FLAGS_CAST_SUM 16
 #define TRILOGY_FLAGS_DEFAULT (TRILOGY_FLAGS_CAST)
 
 struct rb_trilogy_cast_options {
@@ -16,6 +17,7 @@ struct rb_trilogy_cast_options {
     bool cast_booleans;
     bool database_local_time;
     bool flatten_rows;
+    bool cast_sum;
 };
 
 struct column_info {

--- a/contrib/ruby/ext/trilogy-ruby/trilogy-ruby.h
+++ b/contrib/ruby/ext/trilogy-ruby/trilogy-ruby.h
@@ -9,7 +9,7 @@
 #define TRILOGY_FLAGS_CAST_BOOLEANS 2
 #define TRILOGY_FLAGS_LOCAL_TIMEZONE 4
 #define TRILOGY_FLAGS_FLATTEN_ROWS 8
-#define TRILOGY_FLAGS_CAST_SUM 16
+#define TRILOGY_FLAGS_CAST_ALL_DECIMALS_TO_BIGDECIMALS 16
 #define TRILOGY_FLAGS_DEFAULT (TRILOGY_FLAGS_CAST)
 
 struct rb_trilogy_cast_options {
@@ -17,7 +17,7 @@ struct rb_trilogy_cast_options {
     bool cast_booleans;
     bool database_local_time;
     bool flatten_rows;
-    bool cast_sum;
+    bool cast_decimals_to_bigdecimals;
 };
 
 struct column_info {

--- a/contrib/ruby/test/cast_test.rb
+++ b/contrib/ruby/test/cast_test.rb
@@ -64,6 +64,7 @@ class CastTest < TrilogyTest
     assert_equal [[false], [true]], results
   end
 
+
   def test_integer_cast
     @client.query(<<-SQL)
       INSERT INTO trilogy_test (small_int_test, medium_int_test, int_test, big_int_test, year_test)
@@ -114,6 +115,46 @@ class CastTest < TrilogyTest
     SQL
 
     assert_equal [[-128, -32768, -8388608, -2147483648, -9223372036854775808, 0]], results
+  end
+
+  def test_sum_result_int_cast
+    @client.query(<<-SQL)
+      INSERT INTO trilogy_test (int_test) VALUES (1), (2), (3)
+    SQL
+
+    results = @client.query(<<-SQL).to_a
+      SELECT int_test FROM trilogy_test ORDER BY id ASC
+    SQL
+
+    assert_equal [ [1], [2], [3] ], results
+
+    results = @client.query(<<-SQL).to_a
+      SELECT SUM(int_test) FROM trilogy_test
+    SQL
+
+    assert_equal [[6]], results
+    assert_kind_of Integer, results[0][0]
+  end
+
+  def test_sum_result_decimal_cast
+    @client.query(<<-SQL)
+      INSERT INTO trilogy_test (int_test) VALUES (1), (2), (3)
+    SQL
+
+    results = @client.query(<<-SQL).to_a
+      SELECT int_test FROM trilogy_test ORDER BY id ASC
+    SQL
+
+    assert_equal [ [1], [2], [3] ], results
+
+    @client.query_flags |= Trilogy::QUERY_FLAGS_CAST_SUM
+
+    results = @client.query(<<-SQL).to_a
+      SELECT SUM(int_test) FROM trilogy_test
+    SQL
+
+    assert_equal [[6]], results
+    assert_kind_of BigDecimal, results[0][0]
   end
 
   def test_float_cast

--- a/contrib/ruby/test/cast_test.rb
+++ b/contrib/ruby/test/cast_test.rb
@@ -64,7 +64,6 @@ class CastTest < TrilogyTest
     assert_equal [[false], [true]], results
   end
 
-
   def test_integer_cast
     @client.query(<<-SQL)
       INSERT INTO trilogy_test (small_int_test, medium_int_test, int_test, big_int_test, year_test)
@@ -147,7 +146,7 @@ class CastTest < TrilogyTest
 
     assert_equal [ [1], [2], [3] ], results
 
-    @client.query_flags |= Trilogy::QUERY_FLAGS_CAST_SUM
+    @client.query_flags |= Trilogy::QUERY_FLAGS_CAST_ALL_DECIMALS_TO_BIGDECIMALS
 
     results = @client.query(<<-SQL).to_a
       SELECT SUM(int_test) FROM trilogy_test


### PR DESCRIPTION
In https://github.com/github/trilogy/pull/37 there was a change that updated the value of SUM to be Integer if what is being summed are all Integers. It used to be that it will _always_ return a Decimal type.

When we pulled in that change, there were tests that failed because we were doing arthimitic operations on the result of queries that have SUM. Ruby will have different results if you divide intergers and decimals.

In order to keep that behavior for us (GitHub) while allowing other consumers to use SUM and expect the _right_ type we are introducing a new query flag that we can set in our adapter. This query flag will be what will determine if we should be casting the value of SUM to follow the _new_ behavior or roll back to the _old_ behavior