### PR TITLE
Fix msec values for `Time` columns.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
 ### Added
   - Implement multi-result support on the Ruby binding; TRILOGY_CAPABILITIES_MULTI_RESULTS flag enabled by default. #57
 
+### Fixed
+  - Fix msec values for time columns. #59
+
 ## 2.3.0
 
 ### Added

--- a/contrib/ruby/ext/trilogy-ruby/cast.c
+++ b/contrib/ruby/ext/trilogy-ruby/cast.c
@@ -240,7 +240,7 @@ rb_trilogy_cast_value(const trilogy_value_t *value, const struct column_info *co
             // pad out msec_char with zeroes at the end as it could be at any
             // level of precision
             for (size_t i = strlen(msec_char); i < sizeof(msec_char) - 1; i++) {
-                msec_char[i] = 0;
+                msec_char[i] = '0';
             }
 
             return rb_funcall(rb_cTime, options->database_local_time ? id_local : id_utc, 7, INT2NUM(2000), INT2NUM(1),

--- a/contrib/ruby/test/cast_test.rb
+++ b/contrib/ruby/test/cast_test.rb
@@ -368,6 +368,23 @@ class CastTest < TrilogyTest
     assert_equal 108000, time.usec
   end
 
+  def test_time_cast_with_precision
+    @client.query(<<-SQL)
+      INSERT INTO trilogy_test (time_with_precision_test)
+      VALUES ("08:38:18.108")
+    SQL
+
+    results = @client.query(<<-SQL).to_a
+      SELECT time_with_precision_test FROM trilogy_test
+    SQL
+
+    time = results[0][0]
+
+    assert_kind_of Time, time
+    assert_equal "2000-01-01 08:38:18 UTC", time.to_s
+    assert_equal 108000, time.usec
+  end
+
   def test_binary_cast
     @client.query(<<-SQL)
       INSERT INTO trilogy_test (binary_test, varbinary_test)

--- a/contrib/ruby/test/test_helper.rb
+++ b/contrib/ruby/test/test_helper.rb
@@ -109,6 +109,7 @@ class TrilogyTest < Minitest::Test
       `date_test` DATE DEFAULT NULL,
       `date_time_test` DATETIME DEFAULT NULL,
       `date_time_with_precision_test` DATETIME(3) DEFAULT NULL,
+      `time_with_precision_test` TIME(3) DEFAULT NULL,
       `timestamp_test` TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
       `time_test` TIME DEFAULT NULL,
       `year_test` YEAR(4) DEFAULT NULL,


### PR DESCRIPTION
Time columns with precision of less than 6 were not being padded out properly, resulting in an incorrect msec value.