### PR TITLE
Raise all SystemCallErrors as `Trilogy::Error`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/).
     Trilogy client can now accept an `:encoding` option, which will tell the connection to use the specified encoding,
     and will ensure that outgoing query strings are transcoded appropriately. If no encoding is supplied,
     utf8mb4 is used by default. #64
+  - All SystemCallErrors classified as `Trilogy::Error`.
 
 ## 2.3.0
 


### PR DESCRIPTION
### Background

See https://github.com/github/trilogy/pull/58 for more context.

This allows syscall errors to be rescued generically by `Trilogy::Error`, or handled individually by consumers using their original Errno classes.

To make this work, we subclass all of the SystemCallErrors and include the base error module on each of them.

I've also removed the constructors from the existing Errno class subclasses (`Trilogy::TimeoutError`, `Trilogy::ConnectionClosedError`, etc.). We never set an `error_code` on syscall errors, so the constructors shouldn't be needed.

If anyone has input on a better way to handle including the `Trilogy::Error` module on all of the Errno classes, let me know! Enumerating descendants of `SystemCallError`, subclassing them, and including `Trilogy::Error` seems like the most straightforward approach so far, but is admittedly not pretty. 