### PR TITLE
Ruby: Implement Client#discard! to cleanly dispose of connection post fork

### DIFF
--- a/inc/trilogy/client.h
+++ b/inc/trilogy/client.h
@@ -587,4 +587,18 @@ int trilogy_close_recv(trilogy_conn_t *conn);
  */
 void trilogy_free(trilogy_conn_t *conn);
 
+/* trilogy_free - Discard the connection and free any internal buffers.
+ *
+ * The server won't be notified that connection was closed. This is useful to
+ * silently close connections that were inherited after forking without disrupting
+ * the parent's process connections.
+ *
+ * conn - A pre-initialized trilogy_conn_t pointer.
+ *
+ * Return values:
+ *   TRILOGY_OK                 - The connection was successfuly discarded and freed.
+ *   TRILOGY_SYSERR             - A system error occurred, check errno. The connection wasn't freed.
+ */
+int trilogy_discard(trilogy_conn_t *conn);
+
 #endif

--- a/inc/trilogy/socket.h
+++ b/inc/trilogy/socket.h
@@ -107,5 +107,6 @@ static inline int trilogy_sock_fd(trilogy_sock_t *sock) { return sock->fd_cb(soc
 trilogy_sock_t *trilogy_sock_new(const trilogy_sockopt_t *opts);
 int trilogy_sock_resolve(trilogy_sock_t *raw);
 int trilogy_sock_upgrade_ssl(trilogy_sock_t *raw);
+int trilogy_sock_discard(trilogy_sock_t *sock);
 
 #endif

--- a/src/client.c
+++ b/src/client.c
@@ -763,4 +763,13 @@ void trilogy_free(trilogy_conn_t *conn)
     trilogy_buffer_free(&conn->packet_buffer);
 }
 
+int trilogy_discard(trilogy_conn_t *conn)
+{
+    int rc = trilogy_sock_discard(conn->socket);
+    if (rc == TRILOGY_OK) {
+        trilogy_free(conn);
+    }
+    return rc;
+}
+
 #undef CHECKED

--- a/src/socket.c
+++ b/src/socket.c
@@ -621,3 +621,28 @@ fail:
     sock->ssl = NULL;
     return TRILOGY_OPENSSL_ERR;
 }
+
+int trilogy_sock_discard(trilogy_sock_t *_sock)
+{
+    struct trilogy_sock *sock = (struct trilogy_sock *)_sock;
+
+    if (sock->fd < 0) {
+        return TRILOGY_OK;
+    }
+
+    int null_fd = open("/dev/null", O_RDWR | O_CLOEXEC);
+    if (null_fd < 0) {
+        return TRILOGY_SYSERR;
+    }
+
+    if (dup2(null_fd, sock->fd) < 0) {
+        close(null_fd);
+        return TRILOGY_SYSERR;
+    }
+
+    if (close(null_fd) < 0) {
+        return TRILOGY_SYSERR;
+    }
+
+    return TRILOGY_OK;
+}


### PR DESCRIPTION
If you use `Client#close` on a connection that was inherited from a parent it will close the connection for the parent.

Instead we need to use some POSIX magic to close the file descriptor without emitting any close notification, so that the server isn't mislead into closing the connection on its side.

cc @matthewd as we just discussed this.
and cc @adrianna-chang-shopify as the trilogy-adapter will need to be updated to use that new method: https://github.com/github/activerecord-trilogy-adapter/blob/592d98f25ab3e21e0d4f0d9ebc51bb932fd547b3/lib/active_record/connection_adapters/trilogy_adapter.rb#L160