### PR TITLE
[Docs] Fix Trilogy `TRILOGY_CAPABILITIES` docs

### DIFF
--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -90,16 +90,14 @@
      * From client: the client is interactive.                                                                         \
      */                                                                                                                \
     XX(TRILOGY_CAPABILITIES_INTERACTIVE, 0x00000400)                                                                   \
-    /* Not implemented.                                                                                                \
-     *                                                                                                                 \
-     * From server: the server supports ssl.                                                                           \
+    /* From server: the server supports ssl.                                                                           \
      *                                                                                                                 \
      * From client: tells the server it should switch to an ssl connection.                                            \
      */                                                                                                                \
     XX(TRILOGY_CAPABILITIES_SSL, 0x00000800)                                                                           \
-    /* Not used.                                                                                                       \
+    /* From server: the server supports transactions and is capable of reporting transaction status.                   \
      *                                                                                                                 \
-     * This is assumed for the 4.1+ protocol.                                                                          \
+     * From client: the client is aware of servers that support transactions.                                          \
      */                                                                                                                \
     XX(TRILOGY_CAPABILITIES_TRANSACTIONS, 0x00002000)                                                                  \
     /* Not used.                                                                                                       \
@@ -112,9 +110,7 @@
      * scheme. This will always be set.                                                                                \
      */                                                                                                                \
     XX(TRILOGY_CAPABILITIES_SECURE_CONNECTION, 0x00008000)                                                             \
-    /* Not implemented.                                                                                                \
-     *                                                                                                                 \
-     * From server: the server can handle multiple statements per                                                      \
+    /* From server: the server can handle multiple statements per                                                      \
      * query/prepared statement.                                                                                       \
      *                                                                                                                 \
      * From client: tells the server it may send multiple statements per                                               \


### PR DESCRIPTION
This PR tweaks a couple of things with our `TRILOGY_CAPABILITIES` docs: 

* I don't think the description for `TRILOGY_CAPABILITIES_TRANSACTIONS` is correct -- AFAICT it _is_ supported, so I've updated the description to match.
* Same thing with `TRILOGY_CAPABILITIES_SSL` - it said this flag wasn't supported, but Trilogy has SSL support.
* We were also saying that `MULTI_STATEMENTS` still wasn't supported, so removed that line too.