### PR TITLE
No need to accept `multi_result` as conn option in Ruby binding

### DIFF
--- a/contrib/ruby/ext/trilogy-ruby/cext.c
+++ b/contrib/ruby/ext/trilogy-ruby/cext.c
@@ -26,7 +26,7 @@ static ID id_socket, id_host, id_port, id_username, id_password, id_found_rows, 
     id_write_timeout, id_keepalive_enabled, id_keepalive_idle, id_keepalive_interval, id_keepalive_count,
     id_ivar_affected_rows, id_ivar_fields, id_ivar_last_insert_id, id_ivar_rows, id_ivar_query_time, id_password,
     id_database, id_ssl_ca, id_ssl_capath, id_ssl_cert, id_ssl_cipher, id_ssl_crl, id_ssl_crlpath, id_ssl_key,
-    id_ssl_mode, id_tls_ciphersuites, id_tls_min_version, id_tls_max_version, id_multi_statement, id_multi_result,
+    id_ssl_mode, id_tls_ciphersuites, id_tls_min_version, id_tls_max_version, id_multi_statement,
     id_from_code, id_from_errno, id_connection_options;
 
 struct trilogy_ctx {
@@ -455,12 +455,8 @@ static VALUE rb_trilogy_initialize(VALUE self, VALUE encoding, VALUE charset, VA
         connopt.flags |= TRILOGY_CAPABILITIES_FOUND_ROWS;
     }
 
-    if (RTEST(rb_hash_aref(opts, ID2SYM(id_multi_result)))) {
-        connopt.flags |= TRILOGY_CAPABILITIES_MULTI_RESULTS;
-    }
-
     if (RTEST(rb_hash_aref(opts, ID2SYM(id_multi_statement)))) {
-        connopt.flags |= TRILOGY_CAPABILITIES_MULTI_STATEMENTS | TRILOGY_CAPABILITIES_MULTI_RESULTS;
+        connopt.flags |= TRILOGY_CAPABILITIES_MULTI_STATEMENTS;
     }
 
     if ((val = rb_hash_aref(opts, ID2SYM(id_ssl_ca))) != Qnil) {
@@ -1131,7 +1127,6 @@ RUBY_FUNC_EXPORTED void Init_cext()
     id_tls_min_version = rb_intern("tls_min_version");
     id_tls_max_version = rb_intern("tls_max_version");
     id_multi_statement = rb_intern("multi_statement");
-    id_multi_result = rb_intern("multi_result");
     id_from_code = rb_intern("from_code");
     id_from_errno = rb_intern("from_errno");
     id_ivar_affected_rows = rb_intern("@affected_rows");

--- a/contrib/ruby/test/client_test.rb
+++ b/contrib/ruby/test/client_test.rb
@@ -185,7 +185,7 @@ class ClientTest < TrilogyTest
   end
 
   def test_trilogy_multiple_results
-    client = new_tcp_client(multi_result: true)
+    client = new_tcp_client
     create_test_table(client)
 
     client.query("DROP PROCEDURE IF EXISTS test_proc")
@@ -206,7 +206,7 @@ class ClientTest < TrilogyTest
   end
 
   def test_trilogy_multiple_results_doesnt_allow_multi_statement_queries
-    client = new_tcp_client(multi_result: true)
+    client = new_tcp_client
     create_test_table(client)
 
     assert_raises(Trilogy::QueryError) do

--- a/inc/trilogy/protocol.h
+++ b/inc/trilogy/protocol.h
@@ -124,7 +124,9 @@
      * sets from a query.                                                                                              \
      */                                                                                                                \
     XX(TRILOGY_CAPABILITIES_MULTI_RESULTS, 0x00020000)                                                                 \
-    /* From server: the server is capable of sending multiple result sets from                                         \
+    /* Not implemented.                                                                                                \
+     *                                                                                                                 \
+     * From server: the server is capable of sending multiple result sets from                                         \
      * a prepared statement.                                                                                           \
      *                                                                                                                 \
      * From client: tells the server it's capable of handling multiple result                                          \


### PR DESCRIPTION
Follow up to https://github.com/github/trilogy/pull/57

We added the ability to pass `:multi_result` as a connection option to the client in the Ruby binding, but the `MULTI_RESULTS` flag is set by default so this isn't necessary. (I made the changes to the Ruby binding before we decided to set the flag as part of the default bitmask).

Might as well clean this code up in the C-ext :)