### PR TITLE
Set `error_code` on Trilogy::TimeoutError

### DIFF
--- a/contrib/ruby/lib/trilogy.rb
+++ b/contrib/ruby/lib/trilogy.rb
@@ -64,6 +64,11 @@ class Trilogy
 
   class TimeoutError < Errno::ETIMEDOUT
     include ConnectionError
+
+    def initialize(error_message = nil, error_code = nil)
+      super
+      @error_code = error_code
+    end
   end
 
   class ConnectionRefusedError < Errno::ECONNREFUSED


### PR DESCRIPTION
I mistakenly removed the constructor that sets `error_code` on `Trilogy::TimeoutError` in https://github.com/github/trilogy/pull/63. I thought that since it was a syscall error, we'd never set an error code on timeout errs, but we _do_ raise a `TimeoutError` with an error code [here](https://github.com/github/trilogy/blob/main/contrib/ruby/lib/trilogy.rb#L87).